### PR TITLE
refactor: harden API transport boundaries and session recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Keep network access and server/client separation explicit. These rules protect c
   - API infrastructure under `src/lib/` (transport, session recovery, auth refresh);
   - auth bootstrap modules (for example Telegram sign-in exchange);
   - Next.js Route Handlers (`src/app/**/route.ts`).
-- **Components, hooks, and pages** call typed endpoint modules (`*_api.ts`, `*.server.ts` loaders, or feature `_lib/` clients) — not `fetch`, not raw paths.
+- **Components, hooks, and pages** call typed endpoint modules (`*_api.ts`, feature `_lib/` clients) or thin `*.server.ts` loaders that wrap those modules — not `fetch`, not raw paths.
 
 ### Server and client imports
 
@@ -132,8 +132,9 @@ Keep network access and server/client separation explicit. These rules protect c
 
 ### Endpoint paths
 
-- Do not put API path strings (`v1/...`, `/v1/...`) in components or hooks.
-- Endpoint paths belong in endpoint modules next to the feature (`admin-api.ts`, `feedApi.ts`, `feed.server.ts`, etc.).
+- Do not put API path strings (`v1/...`, `/v1/...`) in components, hooks, or `*.server.ts` loaders.
+- Endpoint paths belong in endpoint modules next to the feature (`admin-api.ts`, `feedApi.ts`, `gig-form-api.ts`, etc.).
+- Server loaders (`*.server.ts`) are thin wrappers: they call endpoint-module functions and may add server-only options (for example ISR `next.revalidate`). They must not duplicate path strings.
 - Hooks and components call named functions (`fetchFeedPage`, `lookupGig`, `getCountries`) and receive typed results.
 
 ## File placement

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,31 @@ Apply these rules to the whole repository unless a more specific instruction exi
 - Inferior or shortcut options may be listed **only after** presenting the preferred approach, **or** when the user explicitly requests alternatives. Always label them as not the best/default choice and explain why (tradeoffs, debt, limits).
 - Perfection everywhere is not required, but **initial decisions should aim at the right long-term shape**; shortcuts must be conscious and explicit, not silent defaults.
 
+## HTTP and runtime boundaries
+
+Keep network access and server/client separation explicit. These rules protect caching, bundle boundaries, and API contract ownership.
+
+### Where HTTP calls may live
+
+- **Default:** app code does not call `fetch` directly.
+- **Allowed `fetch` sites:**
+  - API infrastructure under `src/lib/` (transport, session recovery, auth refresh);
+  - auth bootstrap modules (for example Telegram sign-in exchange);
+  - Next.js Route Handlers (`src/app/**/route.ts`).
+- **Components, hooks, and pages** call typed endpoint modules (`*_api.ts`, `*.server.ts` loaders, or feature `_lib/` clients) — not `fetch`, not raw paths.
+
+### Server and client imports
+
+- Files named `*.server.ts` (or modules with `import 'server-only'`) are **server-only**. Do not import browser APIs, client env, React client hooks, or DOM globals into them.
+- Client modules (`'use client'`, `*.client.ts`, hooks) must not import server-only modules — not even for types. Share shapes via colocated `*.types.ts`, `types/`, or feature `_lib/` files without `'server-only'`.
+- If a module is imported from both server and client, split it: server-safe transport/wrappers on one side, browser UI/session effects on the other.
+
+### Endpoint paths
+
+- Do not put API path strings (`v1/...`, `/v1/...`) in components or hooks.
+- Endpoint paths belong in endpoint modules next to the feature (`admin-api.ts`, `feedApi.ts`, `feed.server.ts`, etc.).
+- Hooks and components call named functions (`fetchFeedPage`, `lookupGig`, `getCountries`) and receive typed results.
+
 ## File placement
 
 - Do not add a new file when the code has a **single call site** — colocate it in the existing module (component, service, route, or parser) instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ Apply these rules to the whole repository unless a more specific instruction exi
 - Prefer `interface` over `type` for object shapes unless `type` is clearly the better fit.
 - Use `type` for unions, intersections, mapped types, conditional types, tuples, and other patterns that interfaces cannot express cleanly.
 - Keep type imports separate from value imports. Do not mix them in one import statement.
+- Default: keep param/DTO types in the owning module (`feedApi.ts`, `admin-api.ts`, etc.).
+- Create a colocated `*.types.ts` only when a consumer cannot import the owning module (for example client code must not import `*.server.ts`), or when the same shapes are shared across modules that must stay decoupled from that owner's runtime.
+- Do not extract types into `*.types.ts` only because they are exported or used in tests.
 - Files under `types/` and files named `*.types.ts` must export **types only** (`interface`, `type`, `enum`, type-only helpers). Put runtime constants and functions in a colocated `*.constants.ts` file or the owning module artifact (service, parser, controller).
 
 ## Strictness
@@ -124,7 +127,7 @@ Keep network access and server/client separation explicit. These rules protect c
 ### Server and client imports
 
 - Files named `*.server.ts` (or modules with `import 'server-only'`) are **server-only**. Do not import browser APIs, client env, React client hooks, or DOM globals into them.
-- Client modules (`'use client'`, `*.client.ts`, hooks) must not import server-only modules — not even for types. Share shapes via colocated `*.types.ts`, `types/`, or feature `_lib/` files without `'server-only'`.
+- Client modules (`'use client'`, `*.client.ts`, hooks) must not import server-only modules — not even for types. In that case only, share shapes via colocated `*.types.ts`, `types/`, or feature `_lib/` files without `'server-only'`. Do not invent a `*.types.ts` when consumers can import the owning non-server module directly.
 - If a module is imported from both server and client, split it: server-safe transport/wrappers on one side, browser UI/session effects on the other.
 
 ### Endpoint paths

--- a/src/app/admin/_lib/admin-api.test.ts
+++ b/src/app/admin/_lib/admin-api.test.ts
@@ -19,8 +19,8 @@ import { GigStatusAPI, GigStatusFilter } from '@/app/admin/gigs/_lib/types';
 
 const mockApiRequest = vi.fn();
 
-vi.mock('@/lib/api', () => ({
-  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+vi.mock('@/lib/api-session-client', () => ({
+  apiClientRequest: (...args: unknown[]) => mockApiRequest(...args),
 }));
 
 describe('fetchAdminDashboard', () => {

--- a/src/app/admin/_lib/admin-api.ts
+++ b/src/app/admin/_lib/admin-api.ts
@@ -7,7 +7,7 @@ import type {
   GigStatusFilter,
 } from '@/app/admin/gigs/_lib/types';
 import type { AdminGigsSortBy, AdminGigsSortOrder } from '@/app/admin/gigs/_lib/admin-gigs-sort';
-import { apiRequest } from '@/lib/api';
+import { apiClientRequest } from '@/lib/api-session-client';
 import { isRecord } from '@/lib/is-record';
 
 const V1_ADMIN_API_PREFIX = 'v1/admin/';
@@ -305,17 +305,17 @@ function buildAdminTranslationsEndpoint(params: FetchAdminTranslationsParams): s
 }
 
 export async function fetchAdminDashboard(): Promise<AdminDashboard> {
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}dashboard`, 'GET');
+  const raw = await apiClientRequest<unknown>(`${V1_ADMIN_API_PREFIX}dashboard`, 'GET');
   return parseAdminDashboard(raw);
 }
 
 export async function fetchAdminLocales(): Promise<readonly SupportedLocale[]> {
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}locales`, 'GET');
+  const raw = await apiClientRequest<unknown>(`${V1_ADMIN_API_PREFIX}locales`, 'GET');
   return parseAdminLocalesList(raw);
 }
 
 export async function fetchAdminGigs(params: FetchAdminGigsParams): Promise<AdminGigsList> {
-  const raw = await apiRequest<unknown>(buildAdminGigsEndpoint(params), 'GET');
+  const raw = await apiClientRequest<unknown>(buildAdminGigsEndpoint(params), 'GET');
   return parseAdminGigsList(raw);
 }
 
@@ -323,9 +323,14 @@ export async function fetchAdminGigByPublicId(
   params: FetchAdminGigByPublicIdParams,
 ): Promise<AdminGigFormData> {
   const publicId = encodeURIComponent(params.publicId.trim());
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}gig/${publicId}`, 'GET', undefined, {
-    signal: params.signal,
-  });
+  const raw = await apiClientRequest<unknown>(
+    `${V1_ADMIN_API_PREFIX}gig/${publicId}`,
+    'GET',
+    undefined,
+    {
+      signal: params.signal,
+    },
+  );
   return parseAdminGigFormData(raw);
 }
 
@@ -333,7 +338,7 @@ export async function patchAdminLocale(
   iso: string,
   body: PatchAdminLocaleBody,
 ): Promise<SupportedLocale> {
-  const raw = await apiRequest<unknown>(
+  const raw = await apiClientRequest<unknown>(
     `${V1_ADMIN_API_PREFIX}locales/${encodeURIComponent(iso)}`,
     'PATCH',
     body,
@@ -344,28 +349,31 @@ export async function patchAdminLocale(
 export async function patchAdminLocalesOrder(
   locales: readonly LocaleOrderUpdate[],
 ): Promise<readonly SupportedLocale[]> {
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}locales/order`, 'PATCH', {
+  const raw = await apiClientRequest<unknown>(`${V1_ADMIN_API_PREFIX}locales/order`, 'PATCH', {
     locales,
   });
   return parseAdminLocalesList(raw);
 }
 
 export async function fetchAdminTranslationNamespaces(): Promise<readonly string[]> {
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}translations/namespaces`, 'GET');
+  const raw = await apiClientRequest<unknown>(
+    `${V1_ADMIN_API_PREFIX}translations/namespaces`,
+    'GET',
+  );
   return parseAdminTranslationNamespacesList(raw);
 }
 
 export async function fetchAdminTranslations(
   params: FetchAdminTranslationsParams,
 ): Promise<readonly AdminTranslationRecord[]> {
-  const raw = await apiRequest<unknown>(buildAdminTranslationsEndpoint(params), 'GET');
+  const raw = await apiClientRequest<unknown>(buildAdminTranslationsEndpoint(params), 'GET');
   return parseAdminTranslationsList(raw);
 }
 
 export async function putAdminTranslation(
   body: PutAdminTranslationBody,
 ): Promise<AdminTranslationRecord> {
-  const raw = await apiRequest<unknown>(`${V1_ADMIN_API_PREFIX}translations`, 'PUT', body);
+  const raw = await apiClientRequest<unknown>(`${V1_ADMIN_API_PREFIX}translations`, 'PUT', body);
   return parseAdminTranslationRecord(raw);
 }
 
@@ -373,7 +381,7 @@ export async function patchAdminTranslationActive(
   id: string,
   body: PatchAdminTranslationActiveBody,
 ): Promise<AdminTranslationRecord> {
-  const raw = await apiRequest<unknown>(
+  const raw = await apiClientRequest<unknown>(
     `${V1_ADMIN_API_PREFIX}translations/${encodeURIComponent(id.trim())}/active`,
     'PATCH',
     body,
@@ -383,27 +391,27 @@ export async function patchAdminTranslationActive(
 
 export function postAdminGigApprove(publicId: string): Promise<void> {
   const encodedPublicId = encodeURIComponent(publicId.trim());
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/approve`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/approve`, 'POST');
 }
 
 export function postAdminGigReject(publicId: string): Promise<void> {
   const encodedPublicId = encodeURIComponent(publicId.trim());
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/reject`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/reject`, 'POST');
 }
 
 export function postAdminGigPost(publicId: string): Promise<void> {
   const encodedPublicId = encodeURIComponent(publicId.trim());
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/post`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}gig/${encodedPublicId}/post`, 'POST');
 }
 
 export function postAdminDigestPublish(): Promise<void> {
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}digest/publish`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}digest/publish`, 'POST');
 }
 
 export function postAdminFeedRevalidate(): Promise<void> {
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}feed/revalidate`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}feed/revalidate`, 'POST');
 }
 
 export function postAdminTranslationsRevalidate(): Promise<void> {
-  return apiRequest<void>(`${V1_ADMIN_API_PREFIX}translations/revalidate`, 'POST');
+  return apiClientRequest<void>(`${V1_ADMIN_API_PREFIX}translations/revalidate`, 'POST');
 }

--- a/src/app/admin/gigs/_components/CreateGigFormClient.tsx
+++ b/src/app/admin/gigs/_components/CreateGigFormClient.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import type { Country } from '@/app/admin/gigs/_lib/countries.server';
+import type { Country } from '@/app/admin/gigs/_lib/countries.types';
 import { useRouter } from 'next/navigation';
 import GigFormFields from '@/app/admin/gigs/_components/gig-form/GigFormFields';
 import PosterField from '@/app/admin/gigs/_components/gig-form/PosterField';

--- a/src/app/admin/gigs/_components/EditGigFormClient.tsx
+++ b/src/app/admin/gigs/_components/EditGigFormClient.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { toast } from '@/hooks/use-toast';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import type { Country } from '@/app/admin/gigs/_lib/countries.server';
+import type { Country } from '@/app/admin/gigs/_lib/countries.types';
 import { useRouter } from 'next/navigation';
 import GigFormFields from '@/app/admin/gigs/_components/gig-form/GigFormFields';
 import PosterField from '@/app/admin/gigs/_components/gig-form/PosterField';

--- a/src/app/admin/gigs/_components/GigFormClient.tsx
+++ b/src/app/admin/gigs/_components/GigFormClient.tsx
@@ -2,7 +2,7 @@
 
 import CreateGigFormClient from '@/app/admin/gigs/_components/CreateGigFormClient';
 import EditGigFormClient from '@/app/admin/gigs/_components/EditGigFormClient';
-import type { Country } from '@/app/admin/gigs/_lib/countries.server';
+import type { Country } from '@/app/admin/gigs/_lib/countries.types';
 
 interface GigFormClientProps {
   countries: Country[];

--- a/src/app/admin/gigs/_components/gig-form/GigFormFields.tsx
+++ b/src/app/admin/gigs/_components/gig-form/GigFormFields.tsx
@@ -8,7 +8,7 @@ import { Field, FieldError, FieldLabel, FieldSeparator } from '@/components/ui/f
 import { Input } from '@/components/ui/input';
 import type { GigFormValues } from '@/app/admin/gigs/_lib/gig-form.shared';
 import { defaultGigFormValues } from '@/app/admin/gigs/_lib/gig-form.shared';
-import type { Country } from '@/app/admin/gigs/_lib/countries.server';
+import type { Country } from '@/app/admin/gigs/_lib/countries.types';
 import { countryIsoToTranslationKey } from '@/lib/i18n/country-iso-to-translation-key';
 import { useT } from '@/providers/I18nProvider';
 

--- a/src/app/admin/gigs/_lib/countries.server.ts
+++ b/src/app/admin/gigs/_lib/countries.server.ts
@@ -2,10 +2,9 @@ import 'server-only';
 
 import { apiPublicRequest } from '@/lib/api-public';
 import { parseCountries } from '@/lib/api-boundary-schemas';
+import type { Country } from '@/app/admin/gigs/_lib/countries.types';
 
-export interface Country {
-  iso: string;
-}
+export type { Country };
 
 export async function getCountries(): Promise<Country[]> {
   const raw = await apiPublicRequest<unknown>('/v1/location/countries', 'GET', undefined, {

--- a/src/app/admin/gigs/_lib/countries.server.ts
+++ b/src/app/admin/gigs/_lib/countries.server.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { apiPublicRequest } from '@/lib/api';
+import { apiPublicRequest } from '@/lib/api-public';
 import { parseCountries } from '@/lib/api-boundary-schemas';
 
 export interface Country {

--- a/src/app/admin/gigs/_lib/countries.types.ts
+++ b/src/app/admin/gigs/_lib/countries.types.ts
@@ -1,0 +1,3 @@
+export interface Country {
+  readonly iso: string;
+}

--- a/src/app/admin/gigs/_lib/gig-form-api.test.ts
+++ b/src/app/admin/gigs/_lib/gig-form-api.test.ts
@@ -1,8 +1,8 @@
-import { apiRequest } from '@/lib/api';
+import { apiClientRequest } from '@/lib/api-session-client';
 import { lookupGig } from '@/app/admin/gigs/_lib/gig-form-api';
 
-vi.mock('@/lib/api', () => ({
-  apiRequest: vi.fn(),
+vi.mock('@/lib/api-session-client', () => ({
+  apiClientRequest: vi.fn(),
 }));
 
 describe('lookupGig', () => {
@@ -11,7 +11,7 @@ describe('lookupGig', () => {
   });
 
   it('should call lookup endpoint with trimmed name and location when request is valid', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({
       gig: null,
     });
 
@@ -20,7 +20,7 @@ describe('lookupGig', () => {
       location: '  Barcelona, ES  ',
     });
 
-    expect(vi.mocked(apiRequest)).toHaveBeenCalledWith(
+    expect(vi.mocked(apiClientRequest)).toHaveBeenCalledWith(
       'v1/gig/lookup',
       'POST',
       {
@@ -32,7 +32,7 @@ describe('lookupGig', () => {
   });
 
   it('should return normalized lookup dates when API returns a matching gig', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({
       gig: {
         title: 'Arctic Monkeys',
         date: '2026-07-01T20:00:00.000Z',
@@ -63,7 +63,7 @@ describe('lookupGig', () => {
   });
 
   it('should return null when API reports no matching gig', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({
       gig: null,
     });
 
@@ -76,7 +76,7 @@ describe('lookupGig', () => {
   });
 
   it('should throw when API returns a matching gig without date', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({
       gig: {
         title: 'Arctic Monkeys',
       },
@@ -94,7 +94,7 @@ describe('lookupGig', () => {
   });
 
   it('should throw when API returns an invalid lookup date', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({
       gig: {
         title: 'Arctic Monkeys',
         date: 'not-a-date',
@@ -137,7 +137,7 @@ describe('lookupGig', () => {
   });
 
   it('should throw when API response omits gig field', async () => {
-    vi.mocked(apiRequest).mockResolvedValueOnce({});
+    vi.mocked(apiClientRequest).mockResolvedValueOnce({});
 
     const action = lookupGig({
       name: 'Arctic Monkeys',

--- a/src/app/admin/gigs/_lib/gig-form-api.ts
+++ b/src/app/admin/gigs/_lib/gig-form-api.ts
@@ -1,4 +1,4 @@
-import { apiRequest } from '@/lib/api';
+import { apiClientRequest } from '@/lib/api-session-client';
 import { gigDateToYMD } from '@/lib/feed/feed.mapper';
 import { isRecord } from '@/lib/is-record';
 
@@ -169,16 +169,16 @@ async function submitGig<TResponse = void>(params: SubmitGigParams): Promise<TRe
     const fd = new FormData();
     fd.append('posterFile', posterFile);
     fd.append('gig', JSON.stringify(gig));
-    return apiRequest<TResponse, FormData>(params.endpoint, params.method, fd);
+    return apiClientRequest<TResponse, FormData>(params.endpoint, params.method, fd);
   }
 
   if (posterUrl) {
-    return apiRequest<TResponse>(params.endpoint, params.method, {
+    return apiClientRequest<TResponse>(params.endpoint, params.method, {
       gig: { ...gig, posterUrl },
     });
   }
 
-  return apiRequest<TResponse>(params.endpoint, params.method, {
+  return apiClientRequest<TResponse>(params.endpoint, params.method, {
     gig,
   });
 }
@@ -192,7 +192,7 @@ export async function lookupGig(params: LookupGigParams): Promise<GigLookupData 
   if (!location) {
     throw new Error('Invalid lookup request: "location" is required');
   }
-  const raw = await apiRequest<GigLookupApiResponseBody>(
+  const raw = await apiClientRequest<GigLookupApiResponseBody>(
     'v1/gig/lookup',
     'POST',
     {

--- a/src/app/feed/_lib/feed.server.test.ts
+++ b/src/app/feed/_lib/feed.server.test.ts
@@ -18,7 +18,7 @@ describe('getFeed', () => {
     });
   });
 
-  it('should fetch public feed with omit-compatible wrapper and ISR revalidate', async () => {
+  it('should pass ISR revalidate options when loading the feed', async () => {
     const { getFeed } = await import('@/app/feed/_lib/feed.server');
 
     await getFeed({
@@ -27,16 +27,12 @@ describe('getFeed', () => {
       city: 'barcelona',
     });
 
-    expect(feedServerApiPublicRequestMock).toHaveBeenCalledWith(
-      'v1/gig?limit=10&country=es&city=barcelona',
-      'GET',
-      undefined,
-      {
-        next: {
-          revalidate: 60,
-        },
+    expect(feedServerApiPublicRequestMock).toHaveBeenCalledOnce();
+    expect(feedServerApiPublicRequestMock.mock.calls[0]?.[3]).toEqual({
+      next: {
+        revalidate: 60,
       },
-    );
+    });
   });
 });
 
@@ -48,7 +44,7 @@ describe('getAvailableGigDates', () => {
     });
   });
 
-  it('should fetch calendar dates with ISR revalidate and return sorted unique YMD values', async () => {
+  it('should pass ISR revalidate options and return sorted unique YMD values', async () => {
     const { getAvailableGigDates } = await import('@/app/feed/_lib/feed.server');
 
     const result = await getAvailableGigDates({
@@ -57,34 +53,11 @@ describe('getAvailableGigDates', () => {
     });
 
     expect(result).toEqual(['2026-04-21', '2026-05-01']);
-    expect(feedServerApiPublicRequestMock).toHaveBeenCalledWith(
-      'v1/gig/dates?country=es&city=barcelona',
-      'GET',
-      undefined,
-      {
-        next: {
-          revalidate: 60,
-        },
+    expect(feedServerApiPublicRequestMock).toHaveBeenCalledOnce();
+    expect(feedServerApiPublicRequestMock.mock.calls[0]?.[3]).toEqual({
+      next: {
+        revalidate: 60,
       },
-    );
-  });
-
-  it('should normalize mixed raw date formats into sorted unique YMD values', async () => {
-    const unixSeconds = 1_700_000_000;
-    feedServerApiPublicRequestMock.mockResolvedValueOnce({
-      dates: ['2026-04-21', '2026-04-21T12:00:00.000Z', unixSeconds],
     });
-
-    const { getAvailableGigDates } = await import('@/app/feed/_lib/feed.server');
-    const { toLocalYMD } = await import('@/lib/utils');
-
-    const result = await getAvailableGigDates({
-      country: 'es',
-      city: 'barcelona',
-    });
-
-    expect(result).toEqual(
-      Array.from(new Set(['2026-04-21', toLocalYMD(new Date(unixSeconds * 1000))])).sort(),
-    );
   });
 });

--- a/src/app/feed/_lib/feed.server.test.ts
+++ b/src/app/feed/_lib/feed.server.test.ts
@@ -4,7 +4,7 @@ const { feedServerApiPublicRequestMock } = vi.hoisted(() => ({
 
 vi.mock('server-only', () => ({}));
 
-vi.mock('@/lib/api', () => ({
+vi.mock('@/lib/api-public', () => ({
   apiPublicRequest: feedServerApiPublicRequestMock,
 }));
 

--- a/src/app/feed/_lib/feed.server.ts
+++ b/src/app/feed/_lib/feed.server.ts
@@ -1,12 +1,8 @@
 import 'server-only';
 
-import { apiPublicRequest } from '@/lib/api-public';
-import {
-  parseV1GigDatesGetResponseBody,
-  parseV1GigGetResponseBody,
-} from '@/lib/api-boundary-schemas';
-import { gigDateToYMD } from '@/lib/feed/feed.mapper';
-import type { V1GigDatesGetResponseBody, V1GigGetResponseBody } from '@/lib/types';
+import { fetchFeedAvailableDates, fetchFeedPage } from './feedApi';
+import { gigDatesToSortedUniqueYmd } from '@/lib/feed/feed.mapper';
+import type { V1GigGetResponseBody } from '@/lib/types';
 
 /** Aligns with `export const revalidate` on the feed page (ISR). */
 const FEED_REVALIDATE_SECONDS = 60; // 60 seconds (1 minute)
@@ -17,21 +13,16 @@ const FEED_ISR_REQUEST_INIT = {
   },
 };
 
-export interface GetFeedParams {
+interface GetFeedParams {
   readonly limit: number;
   readonly country?: string;
   readonly city?: string;
   readonly cursor?: string;
 }
 
-export interface GetAvailableGigDatesParams {
+interface GetAvailableGigDatesParams {
   readonly country: string;
   readonly city: string;
-}
-
-function toSortedUniqueYmdDates(dates: V1GigDatesGetResponseBody['dates']): string[] {
-  const ymd = dates.map((date) => gigDateToYMD(date));
-  return Array.from(new Set(ymd)).sort();
 }
 
 /**
@@ -41,19 +32,13 @@ function toSortedUniqueYmdDates(dates: V1GigDatesGetResponseBody['dates']): stri
 export async function getFeed(params: GetFeedParams): Promise<V1GigGetResponseBody> {
   const { limit, country, city, cursor } = params;
 
-  const qs = new URLSearchParams();
-  qs.set('limit', String(limit));
-  if (cursor) qs.set('cursor', cursor);
-  if (country) qs.set('country', country);
-  if (city) qs.set('city', city);
-
-  const raw = await apiPublicRequest<unknown>(
-    `v1/gig?${qs.toString()}`,
-    'GET',
-    undefined,
-    FEED_ISR_REQUEST_INIT,
-  );
-  return parseV1GigGetResponseBody(raw);
+  return fetchFeedPage({
+    limit,
+    country,
+    city,
+    cursor,
+    requestInit: FEED_ISR_REQUEST_INIT,
+  });
 }
 
 /**
@@ -63,17 +48,11 @@ export async function getFeed(params: GetFeedParams): Promise<V1GigGetResponseBo
 export async function getAvailableGigDates(params: GetAvailableGigDatesParams): Promise<string[]> {
   const { country, city } = params;
 
-  const qs = new URLSearchParams();
-  qs.set('country', country);
-  qs.set('city', city);
+  const response = await fetchFeedAvailableDates({
+    country,
+    city,
+    requestInit: FEED_ISR_REQUEST_INIT,
+  });
 
-  const raw = await apiPublicRequest<unknown>(
-    `v1/gig/dates?${qs.toString()}`,
-    'GET',
-    undefined,
-    FEED_ISR_REQUEST_INIT,
-  );
-  const response = parseV1GigDatesGetResponseBody(raw);
-
-  return toSortedUniqueYmdDates(response.dates);
+  return gigDatesToSortedUniqueYmd(response.dates);
 }

--- a/src/app/feed/_lib/feed.server.ts
+++ b/src/app/feed/_lib/feed.server.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { apiPublicRequest } from '@/lib/api';
+import { apiPublicRequest } from '@/lib/api-public';
 import {
   parseV1GigDatesGetResponseBody,
   parseV1GigGetResponseBody,

--- a/src/app/feed/_lib/feedApi.test.ts
+++ b/src/app/feed/_lib/feedApi.test.ts
@@ -1,21 +1,24 @@
-import { apiPublicRequest } from '@/lib/api';
 import {
   fetchFeedAnchorYmdByPublicId,
   fetchFeedAround,
+  fetchFeedAvailableDates,
   fetchFeedPage,
 } from '@/app/feed/_lib/feedApi';
 
-vi.mock('@/lib/api', () => ({
-  apiPublicRequest: vi.fn(),
+const { apiPublicRequestMock } = vi.hoisted(() => ({
+  apiPublicRequestMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-public', () => ({
+  apiPublicRequest: apiPublicRequestMock,
 }));
 
 describe('fetchFeedPage', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    apiPublicRequestMock.mockReset();
   });
 
   it('should request feed page with location and cursor when params are provided', async () => {
-    const apiPublicRequestMock = vi.mocked(apiPublicRequest);
     apiPublicRequestMock.mockResolvedValueOnce({
       gigs: [],
       prevCursor: 'prev',
@@ -39,18 +42,93 @@ describe('fetchFeedPage', () => {
       'v1/gig?limit=10&cursor=abc&direction=prev&country=es&city=barcelona',
       'GET',
       undefined,
-      { signal: undefined },
+      undefined,
+    );
+  });
+
+  it('should pass requestInit when requestInit is provided', async () => {
+    apiPublicRequestMock.mockResolvedValueOnce({
+      gigs: [],
+      prevCursor: undefined,
+      nextCursor: undefined,
+    });
+
+    await fetchFeedPage({
+      limit: 10,
+      requestInit: {
+        next: {
+          revalidate: 60,
+        },
+      },
+    });
+
+    expect(apiPublicRequestMock).toHaveBeenCalledWith('v1/gig?limit=10', 'GET', undefined, {
+      next: {
+        revalidate: 60,
+      },
+    });
+  });
+
+  it('should merge signal over requestInit when both are provided', async () => {
+    const signal = new AbortController().signal;
+    apiPublicRequestMock.mockResolvedValueOnce({
+      gigs: [],
+      prevCursor: undefined,
+      nextCursor: undefined,
+    });
+
+    await fetchFeedPage({
+      limit: 10,
+      signal,
+      requestInit: {
+        next: {
+          revalidate: 60,
+        },
+      },
+    });
+
+    expect(apiPublicRequestMock).toHaveBeenCalledWith('v1/gig?limit=10', 'GET', undefined, {
+      next: {
+        revalidate: 60,
+      },
+      signal,
+    });
+  });
+});
+
+describe('fetchFeedAvailableDates', () => {
+  beforeEach(() => {
+    apiPublicRequestMock.mockReset();
+  });
+
+  it('should request gig dates for a location when params are provided', async () => {
+    apiPublicRequestMock.mockResolvedValueOnce({
+      dates: ['2026-04-21', '2026-05-01'],
+    });
+
+    const result = await fetchFeedAvailableDates({
+      country: 'es',
+      city: 'barcelona',
+    });
+
+    expect(result).toEqual({
+      dates: ['2026-04-21', '2026-05-01'],
+    });
+    expect(apiPublicRequestMock).toHaveBeenCalledWith(
+      'v1/gig/dates?country=es&city=barcelona',
+      'GET',
+      undefined,
+      undefined,
     );
   });
 });
 
 describe('fetchFeedAround', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    apiPublicRequestMock.mockReset();
   });
 
   it('should request around endpoint when anchor and limits are provided', async () => {
-    const apiPublicRequestMock = vi.mocked(apiPublicRequest);
     apiPublicRequestMock.mockResolvedValueOnce({
       before: [],
       after: [],
@@ -76,25 +154,27 @@ describe('fetchFeedAround', () => {
       'v1/gig/around?anchor=2026-04-21&beforeLimit=10&afterLimit=10&country=es&city=barcelona',
       'GET',
       undefined,
-      { signal: undefined },
+      undefined,
     );
   });
 });
 
 describe('fetchFeedAnchorYmdByPublicId', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    apiPublicRequestMock.mockReset();
   });
 
   it('should return normalized anchor date when publicId is provided', async () => {
-    const apiPublicRequestMock = vi.mocked(apiPublicRequest);
     apiPublicRequestMock.mockResolvedValueOnce({ date: '2026-04-21T19:00:00.000Z' });
 
     const result = await fetchFeedAnchorYmdByPublicId({ publicId: 'abc/def' });
 
     expect(result).toBe('2026-04-21');
-    expect(apiPublicRequestMock).toHaveBeenCalledWith('v1/gig/date/abc%2Fdef', 'GET', undefined, {
-      signal: undefined,
-    });
+    expect(apiPublicRequestMock).toHaveBeenCalledWith(
+      'v1/gig/date/abc%2Fdef',
+      'GET',
+      undefined,
+      undefined,
+    );
   });
 });

--- a/src/app/feed/_lib/feedApi.ts
+++ b/src/app/feed/_lib/feedApi.ts
@@ -1,33 +1,51 @@
-import { apiPublicRequest } from '@/lib/api';
+import { apiPublicRequest } from '@/lib/api-public';
+import type { ApiPublicRequestInit } from '@/lib/api-public';
 import {
   parseV1GigAroundGetResponseBody,
   parseV1GigByPublicIdGetResponseBody,
+  parseV1GigDatesGetResponseBody,
   parseV1GigGetResponseBody,
 } from '@/lib/api-boundary-schemas';
 import { gigDateToYMD } from '@/lib/feed/feed.mapper';
-import type { V1GigAroundGetResponseBody, V1GigGetResponseBody } from '@/lib/types';
+import type {
+  V1GigAroundGetResponseBody,
+  V1GigDatesGetResponseBody,
+  V1GigGetResponseBody,
+} from '@/lib/types';
 
 interface FeedLocationParams {
   readonly country?: string;
   readonly city?: string;
   readonly signal?: AbortSignal;
+  readonly requestInit?: ApiPublicRequestInit;
 }
 
-interface FetchFeedPageParams extends FeedLocationParams {
+export interface FetchFeedPageParams extends FeedLocationParams {
   readonly limit: number;
   readonly cursor?: string;
   readonly direction?: 'prev';
 }
 
-interface FetchFeedAroundParams extends FeedLocationParams {
+export interface FetchFeedAroundParams extends FeedLocationParams {
   readonly anchorYmd: string;
   readonly beforeLimit: number;
   readonly afterLimit: number;
 }
 
+export interface FetchFeedAvailableDatesParams extends FeedLocationParams {
+  readonly country: string;
+  readonly city: string;
+}
+
 export interface FetchFeedAnchorYmdByPublicIdParams {
   readonly publicId: string;
   readonly signal?: AbortSignal;
+  readonly requestInit?: ApiPublicRequestInit;
+}
+
+interface BuildApiPublicRequestInitParams {
+  readonly signal?: AbortSignal;
+  readonly requestInit?: ApiPublicRequestInit;
 }
 
 function appendFeedLocationQuery(qs: URLSearchParams, params: FeedLocationParams): void {
@@ -40,6 +58,21 @@ function withQuery(path: string, qs: URLSearchParams): string {
   return query ? `${path}?${query}` : path;
 }
 
+function buildApiPublicRequestInit(
+  params: BuildApiPublicRequestInitParams,
+): ApiPublicRequestInit | undefined {
+  const { signal, requestInit } = params;
+
+  if (signal === undefined) {
+    return requestInit;
+  }
+
+  return {
+    ...requestInit,
+    signal,
+  };
+}
+
 export async function fetchFeedPage(params: FetchFeedPageParams): Promise<V1GigGetResponseBody> {
   const qs = new URLSearchParams();
   qs.set('limit', String(params.limit));
@@ -47,10 +80,29 @@ export async function fetchFeedPage(params: FetchFeedPageParams): Promise<V1GigG
   if (params.direction) qs.set('direction', params.direction);
   appendFeedLocationQuery(qs, params);
 
-  const raw = await apiPublicRequest<unknown>(withQuery('v1/gig', qs), 'GET', undefined, {
-    signal: params.signal,
-  });
+  const raw = await apiPublicRequest<unknown>(
+    withQuery('v1/gig', qs),
+    'GET',
+    undefined,
+    buildApiPublicRequestInit(params),
+  );
   return parseV1GigGetResponseBody(raw);
+}
+
+export async function fetchFeedAvailableDates(
+  params: FetchFeedAvailableDatesParams,
+): Promise<V1GigDatesGetResponseBody> {
+  const qs = new URLSearchParams();
+  qs.set('country', params.country);
+  qs.set('city', params.city);
+
+  const raw = await apiPublicRequest<unknown>(
+    withQuery('v1/gig/dates', qs),
+    'GET',
+    undefined,
+    buildApiPublicRequestInit(params),
+  );
+  return parseV1GigDatesGetResponseBody(raw);
 }
 
 export async function fetchFeedAround(
@@ -62,9 +114,12 @@ export async function fetchFeedAround(
   qs.set('afterLimit', String(params.afterLimit));
   appendFeedLocationQuery(qs, params);
 
-  const raw = await apiPublicRequest<unknown>(withQuery('v1/gig/around', qs), 'GET', undefined, {
-    signal: params.signal,
-  });
+  const raw = await apiPublicRequest<unknown>(
+    withQuery('v1/gig/around', qs),
+    'GET',
+    undefined,
+    buildApiPublicRequestInit(params),
+  );
   return parseV1GigAroundGetResponseBody(raw);
 }
 
@@ -75,7 +130,7 @@ export async function fetchFeedAnchorYmdByPublicId(
     `v1/gig/date/${encodeURIComponent(params.publicId)}`,
     'GET',
     undefined,
-    { signal: params.signal },
+    buildApiPublicRequestInit(params),
   );
   const res = parseV1GigByPublicIdGetResponseBody(raw);
   return gigDateToYMD(res.date);

--- a/src/app/llms-txt/route.test.ts
+++ b/src/app/llms-txt/route.test.ts
@@ -36,7 +36,7 @@ vi.mock('@/env/client-env', () => ({
   },
 }));
 
-vi.mock('@/lib/translations.server', () => ({
+vi.mock('@/lib/i18n/translations.server', () => ({
   getTranslations: getTranslationsMock,
 }));
 

--- a/src/lib/api-core-http-semantics.test.ts
+++ b/src/lib/api-core-http-semantics.test.ts
@@ -1,4 +1,7 @@
-const PUBLIC_CREDENTIALS_1 = { credentials: 'omit' as const };
+const PUBLIC_REQUEST_OPTIONS = {
+  credentials: 'omit' as const,
+  authRecovery: 'none' as const,
+};
 
 describe('fetchApiJson HTTP semantics', () => {
   beforeEach(() => {
@@ -22,7 +25,7 @@ describe('fetchApiJson HTTP semantics', () => {
 
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS_1);
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
 
     const requestHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
     expect(requestHeaders.get('Accept')).toBe('application/json');
@@ -41,7 +44,7 @@ describe('fetchApiJson HTTP semantics', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, {
-      ...PUBLIC_CREDENTIALS_1,
+      ...PUBLIC_REQUEST_OPTIONS,
       headers: { Accept: 'application/vnd.gigstogether+json' },
     });
 
@@ -66,7 +69,7 @@ describe('fetchApiJson HTTP semantics', () => {
 
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS_1);
+    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
 
     await expect(action).rejects.toMatchObject({
       name: 'ApiError',
@@ -88,7 +91,7 @@ describe('fetchApiJson HTTP semantics', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await expect(
-      fetchApiJson<void>('v1/admin/gig/demo/approve', 'POST', undefined, PUBLIC_CREDENTIALS_1),
+      fetchApiJson<void>('v1/admin/gig/demo/approve', 'POST', undefined, PUBLIC_REQUEST_OPTIONS),
     ).resolves.toBeUndefined();
   });
 
@@ -104,7 +107,9 @@ describe('fetchApiJson HTTP semantics', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await expect(
-      fetchApiJson<void>('v1/gig', 'HEAD', undefined, PUBLIC_CREDENTIALS_1),
+      fetchApiJson<void>('v1/gig', 'HEAD', undefined, PUBLIC_REQUEST_OPTIONS),
     ).resolves.toBeUndefined();
   });
 });
+
+export {};

--- a/src/lib/api-core-http-semantics.test.ts
+++ b/src/lib/api-core-http-semantics.test.ts
@@ -1,7 +1,4 @@
-const PUBLIC_REQUEST_OPTIONS = {
-  credentials: 'omit' as const,
-  authRecovery: 'none' as const,
-};
+const PUBLIC_REQUEST_OPTIONS = { credentials: 'omit' as const };
 
 describe('fetchApiJson HTTP semantics', () => {
   beforeEach(() => {

--- a/src/lib/api-core-http-semantics.test.ts
+++ b/src/lib/api-core-http-semantics.test.ts
@@ -1,0 +1,110 @@
+const PUBLIC_CREDENTIALS_1 = { credentials: 'omit' as const };
+
+describe('fetchApiJson HTTP semantics', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_API_BASE_URL = 'https://api.example.com';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('should set accept header without setting content-type for a GET request', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS_1);
+
+    const requestHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(requestHeaders.get('Accept')).toBe('application/json');
+    expect(requestHeaders.get('Content-Type')).toBeNull();
+  });
+
+  it('should preserve an explicitly provided accept header', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, {
+      ...PUBLIC_CREDENTIALS_1,
+      headers: { Accept: 'application/vnd.gigstogether+json' },
+    });
+
+    const requestHeaders = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(requestHeaders.get('Accept')).toBe('application/vnd.gigstogether+json');
+  });
+
+  it('should parse structured syntax suffix json error responses', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          message: 'Invalid request',
+          code: 'INVALID_REQUEST',
+        }),
+        {
+          status: 400,
+          headers: { 'Content-Type': 'application/problem+json; charset=utf-8' },
+        },
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS_1);
+
+    await expect(action).rejects.toMatchObject({
+      name: 'ApiError',
+      message: 'Invalid request',
+      code: 'INVALID_REQUEST',
+      statusCode: 400,
+    });
+  });
+
+  it('should return undefined for a 204 response without parsing a body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(null, {
+        status: 204,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    await expect(
+      fetchApiJson<void>('v1/admin/gig/demo/approve', 'POST', undefined, PUBLIC_CREDENTIALS_1),
+    ).resolves.toBeUndefined();
+  });
+
+  it('should return undefined for a HEAD response without parsing a body', async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response('not parsed', {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    await expect(
+      fetchApiJson<void>('v1/gig', 'HEAD', undefined, PUBLIC_CREDENTIALS_1),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/api-core.test.ts
+++ b/src/lib/api-core.test.ts
@@ -7,48 +7,13 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
-const SESSION_REQUEST_OPTIONS = {
-  credentials: 'include' as const,
-  authRecovery: 'session' as const,
-};
-
-const PUBLIC_REQUEST_OPTIONS = {
-  credentials: 'omit' as const,
-  authRecovery: 'none' as const,
-};
-
-const AUTH_REQUEST_OPTIONS = {
-  credentials: 'include' as const,
-  authRecovery: 'none' as const,
-};
-
-const { postAuthRefreshMock } = vi.hoisted(() => ({
-  postAuthRefreshMock: vi.fn<() => Promise<boolean>>(),
-}));
-
-const { isTelegramMiniAppMock, waitForTelegramInitDataMock } = vi.hoisted(() => ({
-  isTelegramMiniAppMock: vi.fn<() => boolean>(),
-  waitForTelegramInitDataMock: vi.fn<() => Promise<string>>(),
-}));
-
-vi.mock('@/lib/auth-refresh', () => ({
-  postAuthRefresh: postAuthRefreshMock,
-}));
-
-vi.mock('@/lib/telegram/telegram-webapp', () => ({
-  isTelegramMiniApp: isTelegramMiniAppMock,
-  waitForTelegramInitData: waitForTelegramInitDataMock,
-}));
+const INCLUDE_CREDENTIALS = { credentials: 'include' as const };
+const OMIT_CREDENTIALS = { credentials: 'omit' as const };
 
 describe('fetchApiJson', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_APP_API_BASE_URL = 'https://api.example.com';
     vi.resetModules();
-    postAuthRefreshMock.mockReset();
-    postAuthRefreshMock.mockResolvedValue(false);
-    isTelegramMiniAppMock.mockReset();
-    isTelegramMiniAppMock.mockReturnValue(false);
-    waitForTelegramInitDataMock.mockReset();
   });
 
   afterEach(() => {
@@ -56,120 +21,21 @@ describe('fetchApiJson', () => {
     vi.clearAllMocks();
   });
 
-  it('should retry request once when refresh succeeds after 401', async () => {
-    postAuthRefreshMock.mockResolvedValue(true);
-
+  it('should throw ApiError on 401 without making a second request', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
-      .mockResolvedValueOnce(jsonResponse({ gigs: [] }, 200));
-
-    vi.stubGlobal('fetch', fetchMock);
-
-    const { fetchApiJson } = await import('@/lib/api-core');
-    const result = await fetchApiJson<{ gigs: unknown[] }>(
-      'v1/gig?limit=10',
-      'GET',
-      undefined,
-      SESSION_REQUEST_OPTIONS,
-    );
-
-    expect(result).toEqual({ gigs: [] });
-    expect(postAuthRefreshMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('should throw ApiError with 401 status when request is still unauthorized after refresh retry', async () => {
-    postAuthRefreshMock.mockResolvedValue(true);
-
-    const onUnauthorized = vi.fn();
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
-      .mockResolvedValueOnce(jsonResponse({ message: 'still unauthorized' }, 401));
-
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401));
     vi.stubGlobal('fetch', fetchMock);
 
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await expect(
-      fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-        ...SESSION_REQUEST_OPTIONS,
-        onUnauthorized,
-      }),
+      fetchApiJson('v1/gig?limit=10', 'GET', undefined, OMIT_CREDENTIALS),
     ).rejects.toMatchObject({
       name: 'ApiError',
       statusCode: 401,
     });
-    expect(postAuthRefreshMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-  });
-
-  it('should call onUnauthorized once when second request is still unauthorized', async () => {
-    postAuthRefreshMock.mockResolvedValue(true);
-
-    const onUnauthorized = vi.fn();
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
-      .mockResolvedValueOnce(jsonResponse({ message: 'still unauthorized' }, 401));
-
-    vi.stubGlobal('fetch', fetchMock);
-    const { fetchApiJson } = await import('@/lib/api-core');
-
-    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-      ...SESSION_REQUEST_OPTIONS,
-      onUnauthorized,
-    });
-
-    await expect(action).rejects.toThrow();
-    expect(onUnauthorized).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not trigger refresh flow when endpoint is auth refresh itself', async () => {
-    postAuthRefreshMock.mockResolvedValue(true);
-
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401));
-
-    vi.stubGlobal('fetch', fetchMock);
-    const { fetchApiJson } = await import('@/lib/api-core');
-
-    const action = fetchApiJson('v1/auth/refresh', 'POST', undefined, {
-      ...SESSION_REQUEST_OPTIONS,
-      onUnauthorized: vi.fn(),
-    });
-
-    await expect(action).rejects.toThrow();
-    expect(postAuthRefreshMock).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not run session recovery for a public request after 401', async () => {
-    postAuthRefreshMock.mockResolvedValue(true);
-    isTelegramMiniAppMock.mockReturnValue(true);
-    waitForTelegramInitDataMock.mockResolvedValue('init-data');
-
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401));
-    vi.stubGlobal('fetch', fetchMock);
-    vi.stubGlobal('window', {});
-
-    const { fetchApiJson } = await import('@/lib/api-core');
-
-    await expect(
-      fetchApiJson('v1/gig?limit=10', 'GET', undefined, PUBLIC_REQUEST_OPTIONS),
-    ).rejects.toMatchObject({
-      name: 'ApiError',
-      statusCode: 401,
-    });
-
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(postAuthRefreshMock).not.toHaveBeenCalled();
-    expect(isTelegramMiniAppMock).not.toHaveBeenCalled();
-    expect(waitForTelegramInitDataMock).not.toHaveBeenCalled();
   });
 
   it('should propagate machine-readable error code when backend provides it', async () => {
@@ -190,7 +56,7 @@ describe('fetchApiJson', () => {
       'v1/auth/telegram/web-app',
       'POST',
       { initData: 'abc' },
-      AUTH_REQUEST_OPTIONS,
+      INCLUDE_CREDENTIALS,
     );
 
     await expect(action).rejects.toMatchObject({
@@ -214,7 +80,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
+    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, OMIT_CREDENTIALS);
 
     await expect(action).rejects.toThrow('bad gateway');
   });
@@ -229,7 +95,7 @@ describe('fetchApiJson', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await fetchApiJson<{ ok: boolean }>('v1/receiver/gig', 'POST', formData, {
-      ...SESSION_REQUEST_OPTIONS,
+      ...INCLUDE_CREDENTIALS,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -245,7 +111,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, OMIT_CREDENTIALS);
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.credentials).toBe('omit');
@@ -256,7 +122,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, SESSION_REQUEST_OPTIONS);
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, INCLUDE_CREDENTIALS);
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.credentials).toBe('include');
@@ -267,12 +133,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ gigs: unknown[] }>(
-      'v1/gig',
-      'GET',
-      { ignored: true },
-      PUBLIC_REQUEST_OPTIONS,
-    );
+    await fetchApiJson<{ gigs: unknown[] }>('v1/gig', 'GET', { ignored: true }, OMIT_CREDENTIALS);
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.body).toBeUndefined();
@@ -287,7 +148,7 @@ describe('fetchApiJson', () => {
       'v1/gig/lookup',
       'POST',
       { name: 'test' },
-      SESSION_REQUEST_OPTIONS,
+      INCLUDE_CREDENTIALS,
     );
 
     const init = fetchMock.mock.calls[0]?.[1];
@@ -305,7 +166,7 @@ describe('fetchApiJson', () => {
       'POST',
       { name: 'test' },
       {
-        ...SESSION_REQUEST_OPTIONS,
+        ...INCLUDE_CREDENTIALS,
         headers: {
           'Content-Type': 'application/merge-patch+json',
         },
@@ -317,48 +178,6 @@ describe('fetchApiJson', () => {
     expect(headers.get('Content-Type')).toBe('application/merge-patch+json');
   });
 
-  it('should call onUnauthorized when response is 401 and no refresh retry is attempted', async () => {
-    const onUnauthorized = vi.fn();
-    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
-      jsonResponse(
-        {
-          message: 'unauthorized',
-          code: 'X',
-        },
-        401,
-      ),
-    );
-    vi.stubGlobal('fetch', fetchMock);
-    const { fetchApiJson } = await import('@/lib/api-core');
-
-    const action = fetchApiJson(
-      'v1/auth/telegram/web-app',
-      'POST',
-      { initData: 'x' },
-      { ...AUTH_REQUEST_OPTIONS, onUnauthorized },
-    );
-
-    await expect(action).rejects.toThrow();
-    expect(onUnauthorized).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not call onUnauthorized when response status is not 401', async () => {
-    const onUnauthorized = vi.fn();
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(jsonResponse({ message: 'forbidden' }, 403));
-    vi.stubGlobal('fetch', fetchMock);
-    const { fetchApiJson } = await import('@/lib/api-core');
-
-    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-      ...SESSION_REQUEST_OPTIONS,
-      onUnauthorized,
-    });
-
-    await expect(action).rejects.toThrow('forbidden');
-    expect(onUnauthorized).not.toHaveBeenCalled();
-  });
-
   it('should throw fallback message when json error payload has empty message', async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
@@ -366,7 +185,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig/lookup', 'POST', { name: 'x' }, SESSION_REQUEST_OPTIONS);
+    const action = fetchApiJson('v1/gig/lookup', 'POST', { name: 'x' }, INCLUDE_CREDENTIALS);
 
     await expect(action).rejects.toThrow('Something went wrong');
   });
@@ -383,7 +202,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
+    const action = fetchApiJson('v1/gig', 'GET', undefined, OMIT_CREDENTIALS);
 
     await expect(action).rejects.toThrow('Something went wrong');
   });

--- a/src/lib/api-core.test.ts
+++ b/src/lib/api-core.test.ts
@@ -10,6 +10,70 @@ function jsonResponse(body: unknown, status: number): Response {
 const INCLUDE_CREDENTIALS = { credentials: 'include' as const };
 const OMIT_CREDENTIALS = { credentials: 'omit' as const };
 
+describe('buildUrl', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_API_BASE_URL = 'https://api.example.com';
+    vi.resetModules();
+  });
+
+  it('should build URL from a relative v1 endpoint', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(buildUrl('v1/gig?limit=10')).toBe('https://api.example.com/v1/gig?limit=10');
+  });
+
+  it('should normalize a leading slash on v1 endpoint', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(buildUrl('/v1/location/countries')).toBe(
+      'https://api.example.com/v1/location/countries',
+    );
+  });
+
+  it('should throw when endpoint is an absolute URL', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(() => buildUrl('https://evil.com/v1/gig')).toThrow(
+      'API endpoint must be a relative path under v1/, got: https://evil.com/v1/gig',
+    );
+  });
+
+  it('should throw when endpoint uses a protocol-relative URL', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(() => buildUrl('//evil.com/v1/gig')).toThrow(
+      'API endpoint must be a relative path under v1/, got: //evil.com/v1/gig',
+    );
+  });
+
+  it('should throw when endpoint contains path traversal', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(() => buildUrl('v1/../admin/dashboard')).toThrow(
+      'API endpoint must not contain "..", got: v1/../admin/dashboard',
+    );
+  });
+
+  it('should throw when endpoint is not under v1', async () => {
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(() => buildUrl('admin/dashboard')).toThrow(
+      'API endpoint must start with "v1/", got: admin/dashboard',
+    );
+  });
+
+  it('should throw when API base URL is missing', async () => {
+    delete process.env.NEXT_PUBLIC_APP_API_BASE_URL;
+    vi.resetModules();
+
+    const { buildUrl } = await import('@/lib/api-core');
+
+    expect(() => buildUrl('v1/gig')).toThrow(
+      'Missing NEXT_PUBLIC_APP_API_BASE_URL for direct API calls',
+    );
+  });
+});
+
 describe('fetchApiJson', () => {
   beforeEach(() => {
     process.env.NEXT_PUBLIC_APP_API_BASE_URL = 'https://api.example.com';

--- a/src/lib/api-core.test.ts
+++ b/src/lib/api-core.test.ts
@@ -7,15 +7,37 @@ function jsonResponse(body: unknown, status: number): Response {
   });
 }
 
-const SESSION_CREDENTIALS = { credentials: 'include' as const };
-const PUBLIC_CREDENTIALS = { credentials: 'omit' as const };
+const SESSION_REQUEST_OPTIONS = {
+  credentials: 'include' as const,
+  authRecovery: 'session' as const,
+};
+
+const PUBLIC_REQUEST_OPTIONS = {
+  credentials: 'omit' as const,
+  authRecovery: 'none' as const,
+};
+
+const AUTH_REQUEST_OPTIONS = {
+  credentials: 'include' as const,
+  authRecovery: 'none' as const,
+};
 
 const { postAuthRefreshMock } = vi.hoisted(() => ({
   postAuthRefreshMock: vi.fn<() => Promise<boolean>>(),
 }));
 
+const { isTelegramMiniAppMock, waitForTelegramInitDataMock } = vi.hoisted(() => ({
+  isTelegramMiniAppMock: vi.fn<() => boolean>(),
+  waitForTelegramInitDataMock: vi.fn<() => Promise<string>>(),
+}));
+
 vi.mock('@/lib/auth-refresh', () => ({
   postAuthRefresh: postAuthRefreshMock,
+}));
+
+vi.mock('@/lib/telegram/telegram-webapp', () => ({
+  isTelegramMiniApp: isTelegramMiniAppMock,
+  waitForTelegramInitData: waitForTelegramInitDataMock,
 }));
 
 describe('fetchApiJson', () => {
@@ -24,6 +46,9 @@ describe('fetchApiJson', () => {
     vi.resetModules();
     postAuthRefreshMock.mockReset();
     postAuthRefreshMock.mockResolvedValue(false);
+    isTelegramMiniAppMock.mockReset();
+    isTelegramMiniAppMock.mockReturnValue(false);
+    waitForTelegramInitDataMock.mockReset();
   });
 
   afterEach(() => {
@@ -46,7 +71,7 @@ describe('fetchApiJson', () => {
       'v1/gig?limit=10',
       'GET',
       undefined,
-      SESSION_CREDENTIALS,
+      SESSION_REQUEST_OPTIONS,
     );
 
     expect(result).toEqual({ gigs: [] });
@@ -69,7 +94,7 @@ describe('fetchApiJson', () => {
 
     await expect(
       fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-        ...SESSION_CREDENTIALS,
+        ...SESSION_REQUEST_OPTIONS,
         onUnauthorized,
       }),
     ).rejects.toMatchObject({
@@ -93,7 +118,7 @@ describe('fetchApiJson', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-      ...SESSION_CREDENTIALS,
+      ...SESSION_REQUEST_OPTIONS,
       onUnauthorized,
     });
 
@@ -112,13 +137,39 @@ describe('fetchApiJson', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     const action = fetchApiJson('v1/auth/refresh', 'POST', undefined, {
-      ...SESSION_CREDENTIALS,
+      ...SESSION_REQUEST_OPTIONS,
       onUnauthorized: vi.fn(),
     });
 
     await expect(action).rejects.toThrow();
     expect(postAuthRefreshMock).not.toHaveBeenCalled();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not run session recovery for a public request after 401', async () => {
+    postAuthRefreshMock.mockResolvedValue(true);
+    isTelegramMiniAppMock.mockReturnValue(true);
+    waitForTelegramInitDataMock.mockResolvedValue('init-data');
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401));
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('window', {});
+
+    const { fetchApiJson } = await import('@/lib/api-core');
+
+    await expect(
+      fetchApiJson('v1/gig?limit=10', 'GET', undefined, PUBLIC_REQUEST_OPTIONS),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      statusCode: 401,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(postAuthRefreshMock).not.toHaveBeenCalled();
+    expect(isTelegramMiniAppMock).not.toHaveBeenCalled();
+    expect(waitForTelegramInitDataMock).not.toHaveBeenCalled();
   });
 
   it('should propagate machine-readable error code when backend provides it', async () => {
@@ -139,7 +190,7 @@ describe('fetchApiJson', () => {
       'v1/auth/telegram/web-app',
       'POST',
       { initData: 'abc' },
-      SESSION_CREDENTIALS,
+      AUTH_REQUEST_OPTIONS,
     );
 
     await expect(action).rejects.toMatchObject({
@@ -163,7 +214,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, PUBLIC_CREDENTIALS);
+    const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
 
     await expect(action).rejects.toThrow('bad gateway');
   });
@@ -178,7 +229,7 @@ describe('fetchApiJson', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     await fetchApiJson<{ ok: boolean }>('v1/receiver/gig', 'POST', formData, {
-      ...SESSION_CREDENTIALS,
+      ...SESSION_REQUEST_OPTIONS,
       headers: {
         'Content-Type': 'application/json',
       },
@@ -194,7 +245,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS);
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.credentials).toBe('omit');
@@ -205,7 +256,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, SESSION_CREDENTIALS);
+    await fetchApiJson<{ ok: boolean }>('v1/gig', 'GET', undefined, SESSION_REQUEST_OPTIONS);
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.credentials).toBe('include');
@@ -216,7 +267,12 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    await fetchApiJson<{ gigs: unknown[] }>('v1/gig', 'GET', { ignored: true }, PUBLIC_CREDENTIALS);
+    await fetchApiJson<{ gigs: unknown[] }>(
+      'v1/gig',
+      'GET',
+      { ignored: true },
+      PUBLIC_REQUEST_OPTIONS,
+    );
 
     const init = fetchMock.mock.calls[0]?.[1];
     expect(init?.body).toBeUndefined();
@@ -231,7 +287,7 @@ describe('fetchApiJson', () => {
       'v1/gig/lookup',
       'POST',
       { name: 'test' },
-      SESSION_CREDENTIALS,
+      SESSION_REQUEST_OPTIONS,
     );
 
     const init = fetchMock.mock.calls[0]?.[1];
@@ -249,7 +305,7 @@ describe('fetchApiJson', () => {
       'POST',
       { name: 'test' },
       {
-        ...SESSION_CREDENTIALS,
+        ...SESSION_REQUEST_OPTIONS,
         headers: {
           'Content-Type': 'application/merge-patch+json',
         },
@@ -279,7 +335,7 @@ describe('fetchApiJson', () => {
       'v1/auth/telegram/web-app',
       'POST',
       { initData: 'x' },
-      { ...SESSION_CREDENTIALS, onUnauthorized },
+      { ...AUTH_REQUEST_OPTIONS, onUnauthorized },
     );
 
     await expect(action).rejects.toThrow();
@@ -295,7 +351,7 @@ describe('fetchApiJson', () => {
     const { fetchApiJson } = await import('@/lib/api-core');
 
     const action = fetchApiJson('v1/gig?limit=10', 'GET', undefined, {
-      ...SESSION_CREDENTIALS,
+      ...SESSION_REQUEST_OPTIONS,
       onUnauthorized,
     });
 
@@ -310,7 +366,7 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig/lookup', 'POST', { name: 'x' }, SESSION_CREDENTIALS);
+    const action = fetchApiJson('v1/gig/lookup', 'POST', { name: 'x' }, SESSION_REQUEST_OPTIONS);
 
     await expect(action).rejects.toThrow('Something went wrong');
   });
@@ -327,8 +383,10 @@ describe('fetchApiJson', () => {
     vi.stubGlobal('fetch', fetchMock);
     const { fetchApiJson } = await import('@/lib/api-core');
 
-    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_CREDENTIALS);
+    const action = fetchApiJson('v1/gig', 'GET', undefined, PUBLIC_REQUEST_OPTIONS);
 
     await expect(action).rejects.toThrow('Something went wrong');
   });
 });
+
+export {};

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -6,28 +6,12 @@ type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 const API_BASE_URL = clientEnv.appApiBaseUrl;
 
-export type ApiAuthRecoveryPolicy = 'none' | 'session';
-
 export interface FetchApiJsonOptions extends Omit<RequestInit, 'credentials'> {
   /**
    * Must be set explicitly at every call site.
    * Use `include` for cookie/session requests and `omit` for public cacheable GETs.
    */
   credentials: RequestCredentials;
-  /**
-   * `none` returns the original 401 without session recovery.
-   * `session` tries token refresh and Telegram Mini App re-auth.
-   */
-  authRecovery: ApiAuthRecoveryPolicy;
-  onUnauthorized?: () => void;
-  /**
-   * Internal: set after one `POST v1/auth/refresh` so a second 401 does not loop refresh.
-   */
-  hasAttemptedTokenRefresh?: boolean;
-  /**
-   * Internal: set after one Telegram Mini App re-auth so a second 401 does not loop re-auth.
-   */
-  hasAttemptedTelegramMiniAppReauth?: boolean;
 }
 
 export function buildUrl(endpointOrUrl: string): string {
@@ -36,14 +20,6 @@ export function buildUrl(endpointOrUrl: string): string {
     throw new Error('Missing NEXT_PUBLIC_APP_API_BASE_URL for direct API calls');
   }
   return `${API_BASE_URL.replace(/\/$/, '')}/${endpointOrUrl.replace(/^\//, '')}`;
-}
-
-function isAuthRefreshEndpoint(endpointOrUrl: string): boolean {
-  return endpointOrUrl.includes('v1/auth/refresh');
-}
-
-function isTelegramWebAppAuthEndpoint(endpointOrUrl: string): boolean {
-  return endpointOrUrl.includes('v1/auth/telegram/web-app');
 }
 
 function isJsonContentType(contentType: string): boolean {
@@ -55,75 +31,13 @@ function hasNoResponseBody(method: HttpMethod, response: Response): boolean {
   return method === 'HEAD' || response.status === 204 || response.status === 205;
 }
 
-let authRefreshPromise: Promise<boolean> | null = null;
-let telegramMiniAppReauthPromise: Promise<boolean> | null = null;
-
-async function postAuthRefreshSingleFlight(): Promise<boolean> {
-  if (!authRefreshPromise) {
-    authRefreshPromise = (async () => {
-      try {
-        const { postAuthRefresh } = await import('@/lib/auth-refresh');
-        return await postAuthRefresh();
-      } finally {
-        authRefreshPromise = null;
-      }
-    })();
-  }
-
-  return authRefreshPromise;
-}
-
-async function postTelegramMiniAppReauth(): Promise<boolean> {
-  if (typeof window === 'undefined') {
-    return false;
-  }
-
-  if (!telegramMiniAppReauthPromise) {
-    telegramMiniAppReauthPromise = (async () => {
-      try {
-        const { isTelegramMiniApp, waitForTelegramInitData } = await import(
-          '@/lib/telegram/telegram-webapp'
-        );
-        if (!isTelegramMiniApp()) {
-          return false;
-        }
-
-        const initData = await waitForTelegramInitData();
-        const response = await fetch(buildUrl('v1/auth/telegram/web-app'), {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ initData }),
-        });
-        return response.ok;
-      } catch {
-        return false;
-      } finally {
-        telegramMiniAppReauthPromise = null;
-      }
-    })();
-  }
-
-  return telegramMiniAppReauthPromise;
-}
-
 export async function fetchApiJson<TResponse>(
   endpointOrUrl: string,
   method: HttpMethod,
   data: unknown | undefined,
   init: FetchApiJsonOptions,
 ): Promise<TResponse> {
-  const {
-    authRecovery,
-    onUnauthorized,
-    hasAttemptedTokenRefresh,
-    hasAttemptedTelegramMiniAppReauth,
-    credentials,
-    ...fetchInit
-  } = init;
-  const shouldRecoverSession = authRecovery === 'session';
+  const { credentials, ...fetchInit } = init;
   const hasRequestBody = method !== 'GET' && method !== 'HEAD' && data !== undefined;
   const isFormData = typeof FormData !== 'undefined' && data instanceof FormData;
 
@@ -147,37 +61,6 @@ export async function fetchApiJson<TResponse>(
     credentials,
   });
 
-  if (
-    shouldRecoverSession &&
-    response.status === 401 &&
-    !hasAttemptedTokenRefresh &&
-    !isAuthRefreshEndpoint(endpointOrUrl)
-  ) {
-    const refreshed = await postAuthRefreshSingleFlight();
-    if (refreshed) {
-      return fetchApiJson<TResponse>(endpointOrUrl, method, data, {
-        ...init,
-        hasAttemptedTokenRefresh: true,
-      });
-    }
-  }
-
-  if (
-    shouldRecoverSession &&
-    response.status === 401 &&
-    !hasAttemptedTelegramMiniAppReauth &&
-    !isAuthRefreshEndpoint(endpointOrUrl) &&
-    !isTelegramWebAppAuthEndpoint(endpointOrUrl)
-  ) {
-    const isReauthenticated = await postTelegramMiniAppReauth();
-    if (isReauthenticated) {
-      return fetchApiJson<TResponse>(endpointOrUrl, method, data, {
-        ...init,
-        hasAttemptedTelegramMiniAppReauth: true,
-      });
-    }
-  }
-
   const contentType = response.headers.get('Content-Type') ?? '';
   const result = hasNoResponseBody(method, response)
     ? undefined
@@ -186,9 +69,6 @@ export async function fetchApiJson<TResponse>(
       : await response.text();
 
   if (!response.ok) {
-    if (response.status === 401 && onUnauthorized) {
-      onUnauthorized();
-    }
     if (isRecord(result)) {
       const r = result;
       const msg =

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -39,6 +39,15 @@ function isTelegramWebAppAuthEndpoint(endpointOrUrl: string): boolean {
   return endpointOrUrl.includes('v1/auth/telegram/web-app');
 }
 
+function isJsonContentType(contentType: string): boolean {
+  const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase();
+  return mediaType === 'application/json' || mediaType?.endsWith('+json') === true;
+}
+
+function hasNoResponseBody(method: HttpMethod, response: Response): boolean {
+  return method === 'HEAD' || response.status === 204 || response.status === 205;
+}
+
 let authRefreshPromise: Promise<boolean> | null = null;
 let telegramMiniAppReauthPromise: Promise<boolean> | null = null;
 
@@ -106,21 +115,20 @@ export async function fetchApiJson<TResponse>(
     credentials,
     ...fetchInit
   } = init;
+  const hasRequestBody = method !== 'GET' && method !== 'HEAD' && data !== undefined;
   const isFormData = typeof FormData !== 'undefined' && data instanceof FormData;
 
   const headers = new Headers(fetchInit.headers);
-  if (isFormData) {
+  if (!headers.has('Accept')) {
+    headers.set('Accept', 'application/json');
+  }
+  if (hasRequestBody && isFormData) {
     if (headers.has('Content-Type')) headers.delete('Content-Type');
-  } else if (!headers.has('Content-Type')) {
+  } else if (hasRequestBody && !headers.has('Content-Type')) {
     headers.set('Content-Type', 'application/json');
   }
 
-  const body =
-    method !== 'GET' && method !== 'HEAD' && data !== undefined
-      ? isFormData
-        ? data
-        : JSON.stringify(data)
-      : undefined;
+  const body = hasRequestBody ? (isFormData ? data : JSON.stringify(data)) : undefined;
 
   const response = await fetch(buildUrl(endpointOrUrl), {
     ...fetchInit,
@@ -159,10 +167,12 @@ export async function fetchApiJson<TResponse>(
     }
   }
 
-  const contentType = response.headers.get('Content-Type') || '';
-  const isJson = contentType.includes('application/json');
-
-  const result = isJson ? await response.json() : await response.text();
+  const contentType = response.headers.get('Content-Type') ?? '';
+  const result = hasNoResponseBody(method, response)
+    ? undefined
+    : isJsonContentType(contentType)
+      ? await response.json()
+      : await response.text();
 
   if (!response.ok) {
     if (response.status === 401 && onUnauthorized) {
@@ -175,7 +185,7 @@ export async function fetchApiJson<TResponse>(
       const code = typeof r.code === 'string' ? r.code : undefined;
       throw new ApiError(msg, response.status, code);
     }
-    throw new Error(typeof result === 'string' ? result : 'Something went wrong');
+    throw new Error(typeof result === 'string' && result ? result : 'Something went wrong');
   }
 
   return result as TResponse;

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -14,12 +14,35 @@ export interface FetchApiJsonOptions extends Omit<RequestInit, 'credentials'> {
   credentials: RequestCredentials;
 }
 
-export function buildUrl(endpointOrUrl: string): string {
-  if (/^https?:\/\//i.test(endpointOrUrl)) return endpointOrUrl;
+const API_ENDPOINT_PREFIX = 'v1/';
+
+function assertRelativeApiEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim();
+  if (!trimmed) {
+    throw new Error('API endpoint must be a non-empty relative path.');
+  }
+  if (trimmed.includes('://') || trimmed.startsWith('//')) {
+    throw new Error(`API endpoint must be a relative path under v1/, got: ${endpoint}`);
+  }
+  if (trimmed.includes('..')) {
+    throw new Error(`API endpoint must not contain "..", got: ${endpoint}`);
+  }
+
+  const normalized = trimmed.replace(/^\/+/, '');
+  if (!normalized.startsWith(API_ENDPOINT_PREFIX)) {
+    throw new Error(`API endpoint must start with "v1/", got: ${endpoint}`);
+  }
+
+  return normalized;
+}
+
+export function buildUrl(endpoint: string): string {
   if (!API_BASE_URL) {
     throw new Error('Missing NEXT_PUBLIC_APP_API_BASE_URL for direct API calls');
   }
-  return `${API_BASE_URL.replace(/\/$/, '')}/${endpointOrUrl.replace(/^\//, '')}`;
+
+  const normalizedEndpoint = assertRelativeApiEndpoint(endpoint);
+  return `${API_BASE_URL.replace(/\/$/, '')}/${normalizedEndpoint}`;
 }
 
 function isJsonContentType(contentType: string): boolean {

--- a/src/lib/api-core.ts
+++ b/src/lib/api-core.ts
@@ -6,12 +6,19 @@ type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 const API_BASE_URL = clientEnv.appApiBaseUrl;
 
+export type ApiAuthRecoveryPolicy = 'none' | 'session';
+
 export interface FetchApiJsonOptions extends Omit<RequestInit, 'credentials'> {
   /**
    * Must be set explicitly at every call site.
    * Use `include` for cookie/session requests and `omit` for public cacheable GETs.
    */
   credentials: RequestCredentials;
+  /**
+   * `none` returns the original 401 without session recovery.
+   * `session` tries token refresh and Telegram Mini App re-auth.
+   */
+  authRecovery: ApiAuthRecoveryPolicy;
   onUnauthorized?: () => void;
   /**
    * Internal: set after one `POST v1/auth/refresh` so a second 401 does not loop refresh.
@@ -109,12 +116,14 @@ export async function fetchApiJson<TResponse>(
   init: FetchApiJsonOptions,
 ): Promise<TResponse> {
   const {
+    authRecovery,
     onUnauthorized,
     hasAttemptedTokenRefresh,
     hasAttemptedTelegramMiniAppReauth,
     credentials,
     ...fetchInit
   } = init;
+  const shouldRecoverSession = authRecovery === 'session';
   const hasRequestBody = method !== 'GET' && method !== 'HEAD' && data !== undefined;
   const isFormData = typeof FormData !== 'undefined' && data instanceof FormData;
 
@@ -139,6 +148,7 @@ export async function fetchApiJson<TResponse>(
   });
 
   if (
+    shouldRecoverSession &&
     response.status === 401 &&
     !hasAttemptedTokenRefresh &&
     !isAuthRefreshEndpoint(endpointOrUrl)
@@ -153,6 +163,7 @@ export async function fetchApiJson<TResponse>(
   }
 
   if (
+    shouldRecoverSession &&
     response.status === 401 &&
     !hasAttemptedTelegramMiniAppReauth &&
     !isAuthRefreshEndpoint(endpointOrUrl) &&

--- a/src/lib/api-public.test.ts
+++ b/src/lib/api-public.test.ts
@@ -1,0 +1,37 @@
+const { fetchApiJsonMock } = vi.hoisted(() => ({
+  fetchApiJsonMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-core', () => ({
+  fetchApiJson: fetchApiJsonMock,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    errorFromUnknown: vi.fn(),
+  },
+}));
+
+describe('apiPublicRequest', () => {
+  beforeEach(() => {
+    fetchApiJsonMock.mockReset();
+    fetchApiJsonMock.mockResolvedValue({ ok: true });
+  });
+
+  it('should call pure transport with omit credentials', async () => {
+    const { apiPublicRequest } = await import('@/lib/api-public');
+
+    await apiPublicRequest('v1/gig?limit=10', 'GET');
+
+    expect(fetchApiJsonMock).toHaveBeenCalledWith(
+      'v1/gig?limit=10',
+      'GET',
+      undefined,
+      expect.objectContaining({
+        credentials: 'omit',
+      }),
+    );
+  });
+});
+
+export {};

--- a/src/lib/api-public.ts
+++ b/src/lib/api-public.ts
@@ -4,7 +4,7 @@ import { logger } from '@/lib/logger';
 
 type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-type ApiPublicRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
+export type ApiPublicRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
 
 /**
  * Public API call. Omits cookies and disables session recovery.

--- a/src/lib/api-public.ts
+++ b/src/lib/api-public.ts
@@ -1,0 +1,31 @@
+import { fetchApiJson } from '@/lib/api-core';
+import type { FetchApiJsonOptions } from '@/lib/api-core';
+import { logger } from '@/lib/logger';
+
+type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+type ApiPublicRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
+
+/**
+ * Public API call. Omits cookies and disables session recovery.
+ * Next.js cache behavior is configured explicitly at each server call site.
+ * Safe for server loaders and other modules that must not pull session recovery.
+ */
+export async function apiPublicRequest<TResponse = unknown, TBody = unknown>(
+  endpointOrUrl: string,
+  method: HttpMethod,
+  data?: TBody,
+  init?: ApiPublicRequestInit,
+): Promise<TResponse> {
+  try {
+    const headers = new Headers(init?.headers);
+    return await fetchApiJson<TResponse>(endpointOrUrl, method, data, {
+      ...init,
+      headers,
+      credentials: 'omit',
+    });
+  } catch (e) {
+    logger.errorFromUnknown('api_public_request_failed', e, { endpointOrUrl, method });
+    throw e;
+  }
+}

--- a/src/lib/api-session-client.test.ts
+++ b/src/lib/api-session-client.test.ts
@@ -1,0 +1,65 @@
+import { apiClientRequest, handleApiClientSessionUnauthorized } from '@/lib/api-session-client';
+
+const { fetchApiJsonWithSessionRecoveryMock } = vi.hoisted(() => ({
+  fetchApiJsonWithSessionRecoveryMock: vi.fn(),
+}));
+
+const { clearStoredTelegramClientProfileMock, requestTelegramSignInMock } = vi.hoisted(() => ({
+  clearStoredTelegramClientProfileMock: vi.fn(),
+  requestTelegramSignInMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-session-recovery', () => ({
+  fetchApiJsonWithSessionRecovery: fetchApiJsonWithSessionRecoveryMock,
+}));
+
+vi.mock('@/lib/telegram/telegram-auth', () => ({
+  clearStoredTelegramClientProfile: clearStoredTelegramClientProfileMock,
+  requestTelegramSignIn: requestTelegramSignInMock,
+}));
+
+vi.mock('@/lib/telegram/telegram-webapp', () => ({
+  isTelegramMiniApp: () => false,
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: {
+    errorFromUnknown: vi.fn(),
+  },
+}));
+
+describe('apiClientRequest', () => {
+  beforeEach(() => {
+    fetchApiJsonWithSessionRecoveryMock.mockReset();
+    clearStoredTelegramClientProfileMock.mockReset();
+    requestTelegramSignInMock.mockReset();
+    fetchApiJsonWithSessionRecoveryMock.mockResolvedValue({ ok: true });
+  });
+
+  it('should delegate to session recovery coordinator with onUnauthorized callback', async () => {
+    await apiClientRequest('v1/admin/dashboard', 'GET');
+
+    expect(fetchApiJsonWithSessionRecoveryMock).toHaveBeenCalledWith(
+      'v1/admin/dashboard',
+      'GET',
+      undefined,
+      expect.objectContaining({
+        onUnauthorized: handleApiClientSessionUnauthorized,
+      }),
+    );
+  });
+});
+
+describe('handleApiClientSessionUnauthorized', () => {
+  beforeEach(() => {
+    clearStoredTelegramClientProfileMock.mockReset();
+    requestTelegramSignInMock.mockReset();
+  });
+
+  it('should clear stored profile and request sign-in when not in Telegram Mini App', () => {
+    handleApiClientSessionUnauthorized();
+
+    expect(clearStoredTelegramClientProfileMock).toHaveBeenCalledTimes(1);
+    expect(requestTelegramSignInMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/api-session-client.ts
+++ b/src/lib/api-session-client.ts
@@ -1,0 +1,44 @@
+import type { FetchApiJsonOptions } from '@/lib/api-core';
+import { fetchApiJsonWithSessionRecovery } from '@/lib/api-session-recovery';
+import { logger } from '@/lib/logger';
+import {
+  clearStoredTelegramClientProfile,
+  requestTelegramSignIn,
+} from '@/lib/telegram/telegram-auth';
+import { isTelegramMiniApp } from '@/lib/telegram/telegram-webapp';
+
+type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+type ApiClientRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
+
+/** Clears cached profile and opens sign-in UI after a final session 401. */
+export function handleApiClientSessionUnauthorized(): void {
+  clearStoredTelegramClientProfile();
+  if (!isTelegramMiniApp()) {
+    requestTelegramSignIn();
+  }
+}
+
+/**
+ * Client-side session API call with cookie auth, session recovery, and sign-in UI on 401.
+ */
+export async function apiClientRequest<TResponse = unknown, TBody = unknown>(
+  endpointOrUrl: string,
+  method: HttpMethod,
+  data?: TBody,
+  init?: ApiClientRequestInit,
+): Promise<TResponse> {
+  try {
+    const headers = new Headers(init?.headers);
+    return await fetchApiJsonWithSessionRecovery<TResponse>(endpointOrUrl, method, data, {
+      init: {
+        ...init,
+        headers,
+      },
+      onUnauthorized: handleApiClientSessionUnauthorized,
+    });
+  } catch (e) {
+    logger.errorFromUnknown('api_client_request_failed', e, { endpointOrUrl, method });
+    throw e;
+  }
+}

--- a/src/lib/api-session-recovery.test.ts
+++ b/src/lib/api-session-recovery.test.ts
@@ -1,0 +1,205 @@
+function jsonResponse(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}
+
+const { postAuthRefreshMock } = vi.hoisted(() => ({
+  postAuthRefreshMock: vi.fn<() => Promise<boolean>>(),
+}));
+
+const { isTelegramMiniAppMock, waitForTelegramInitDataMock } = vi.hoisted(() => ({
+  isTelegramMiniAppMock: vi.fn<() => boolean>(),
+  waitForTelegramInitDataMock: vi.fn<() => Promise<string>>(),
+}));
+
+vi.mock('@/lib/auth-refresh', () => ({
+  postAuthRefresh: postAuthRefreshMock,
+}));
+
+vi.mock('@/lib/telegram/telegram-webapp', () => ({
+  isTelegramMiniApp: isTelegramMiniAppMock,
+  waitForTelegramInitData: waitForTelegramInitDataMock,
+}));
+
+describe('fetchApiJsonWithSessionRecovery', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_APP_API_BASE_URL = 'https://api.example.com';
+    vi.resetModules();
+    postAuthRefreshMock.mockReset();
+    postAuthRefreshMock.mockResolvedValue(false);
+    isTelegramMiniAppMock.mockReset();
+    isTelegramMiniAppMock.mockReturnValue(false);
+    waitForTelegramInitDataMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('should retry request once when refresh succeeds after 401', async () => {
+    postAuthRefreshMock.mockResolvedValue(true);
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ gigs: [] }, 200));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+    const result = await fetchApiJsonWithSessionRecovery<{ gigs: unknown[] }>(
+      'v1/gig?limit=10',
+      'GET',
+      undefined,
+      {},
+    );
+
+    expect(result).toEqual({ gigs: [] });
+    expect(postAuthRefreshMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should throw ApiError with 401 status when request is still unauthorized after refresh retry', async () => {
+    postAuthRefreshMock.mockResolvedValue(true);
+
+    const onUnauthorized = vi.fn();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ message: 'still unauthorized' }, 401));
+
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    await expect(
+      fetchApiJsonWithSessionRecovery('v1/gig?limit=10', 'GET', undefined, { onUnauthorized }),
+    ).rejects.toMatchObject({
+      name: 'ApiError',
+      statusCode: 401,
+    });
+    expect(postAuthRefreshMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('should call onUnauthorized once when second request is still unauthorized', async () => {
+    postAuthRefreshMock.mockResolvedValue(true);
+
+    const onUnauthorized = vi.fn();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ message: 'still unauthorized' }, 401));
+
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    const action = fetchApiJsonWithSessionRecovery('v1/gig?limit=10', 'GET', undefined, {
+      onUnauthorized,
+    });
+
+    await expect(action).rejects.toThrow();
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not trigger refresh flow when endpoint is auth refresh itself', async () => {
+    postAuthRefreshMock.mockResolvedValue(true);
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401));
+
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    const action = fetchApiJsonWithSessionRecovery('v1/auth/refresh', 'POST', undefined, {
+      onUnauthorized: vi.fn(),
+    });
+
+    await expect(action).rejects.toThrow();
+    expect(postAuthRefreshMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should retry request after Telegram Mini App re-auth succeeds when token refresh fails', async () => {
+    postAuthRefreshMock.mockResolvedValue(false);
+    isTelegramMiniAppMock.mockReturnValue(true);
+    waitForTelegramInitDataMock.mockResolvedValue('init-data');
+
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'unauthorized' }, 401))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }, 200))
+      .mockResolvedValueOnce(jsonResponse({ gigs: [] }, 200));
+
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('window', {});
+
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    const result = await fetchApiJsonWithSessionRecovery<{ gigs: unknown[] }>(
+      'v1/gig?limit=10',
+      'GET',
+      undefined,
+      {},
+    );
+
+    expect(result).toEqual({ gigs: [] });
+    expect(postAuthRefreshMock).toHaveBeenCalledTimes(1);
+    expect(isTelegramMiniAppMock).toHaveBeenCalledTimes(1);
+    expect(waitForTelegramInitDataMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('should call onUnauthorized on final 401 and skip Telegram re-auth for web-app auth endpoint', async () => {
+    const onUnauthorized = vi.fn();
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      jsonResponse(
+        {
+          message: 'unauthorized',
+          code: 'X',
+        },
+        401,
+      ),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    vi.stubGlobal('window', {});
+    isTelegramMiniAppMock.mockReturnValue(true);
+    waitForTelegramInitDataMock.mockResolvedValue('init-data');
+
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    const action = fetchApiJsonWithSessionRecovery(
+      'v1/auth/telegram/web-app',
+      'POST',
+      { initData: 'x' },
+      { onUnauthorized },
+    );
+
+    await expect(action).rejects.toThrow();
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    expect(isTelegramMiniAppMock).not.toHaveBeenCalled();
+    expect(waitForTelegramInitDataMock).not.toHaveBeenCalled();
+  });
+
+  it('should not call onUnauthorized when response status is not 401', async () => {
+    const onUnauthorized = vi.fn();
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ message: 'forbidden' }, 403));
+    vi.stubGlobal('fetch', fetchMock);
+    const { fetchApiJsonWithSessionRecovery } = await import('@/lib/api-session-recovery');
+
+    const action = fetchApiJsonWithSessionRecovery('v1/gig?limit=10', 'GET', undefined, {
+      onUnauthorized,
+    });
+
+    await expect(action).rejects.toThrow('forbidden');
+    expect(onUnauthorized).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/api-session-recovery.ts
+++ b/src/lib/api-session-recovery.ts
@@ -1,0 +1,134 @@
+import { ApiError } from '@/lib/api-errors';
+import { buildUrl, fetchApiJson } from '@/lib/api-core';
+import type { FetchApiJsonOptions } from '@/lib/api-core';
+import { postAuthRefresh } from '@/lib/auth-refresh';
+
+type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+
+interface SessionRecoveryState {
+  hasAttemptedTokenRefresh?: boolean;
+  hasAttemptedTelegramMiniAppReauth?: boolean;
+}
+
+export interface FetchApiJsonWithSessionRecoveryOptions {
+  init?: Omit<FetchApiJsonOptions, 'credentials'>;
+  onUnauthorized?: () => void;
+  recoveryState?: SessionRecoveryState;
+}
+
+function isAuthRefreshEndpoint(endpointOrUrl: string): boolean {
+  return endpointOrUrl.includes('v1/auth/refresh');
+}
+
+function isTelegramWebAppAuthEndpoint(endpointOrUrl: string): boolean {
+  return endpointOrUrl.includes('v1/auth/telegram/web-app');
+}
+
+let authRefreshPromise: Promise<boolean> | null = null;
+let telegramMiniAppReauthPromise: Promise<boolean> | null = null;
+
+async function postAuthRefreshSingleFlight(): Promise<boolean> {
+  if (!authRefreshPromise) {
+    authRefreshPromise = (async () => {
+      try {
+        return await postAuthRefresh();
+      } finally {
+        authRefreshPromise = null;
+      }
+    })();
+  }
+
+  return authRefreshPromise;
+}
+
+async function postTelegramMiniAppReauth(): Promise<boolean> {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (!telegramMiniAppReauthPromise) {
+    telegramMiniAppReauthPromise = (async () => {
+      try {
+        const { isTelegramMiniApp, waitForTelegramInitData } = await import(
+          '@/lib/telegram/telegram-webapp'
+        );
+        if (!isTelegramMiniApp()) {
+          return false;
+        }
+
+        const initData = await waitForTelegramInitData();
+        const response = await fetch(buildUrl('v1/auth/telegram/web-app'), {
+          method: 'POST',
+          credentials: 'include',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ initData }),
+        });
+        return response.ok;
+      } catch {
+        return false;
+      } finally {
+        telegramMiniAppReauthPromise = null;
+      }
+    })();
+  }
+
+  return telegramMiniAppReauthPromise;
+}
+
+export async function fetchApiJsonWithSessionRecovery<TResponse>(
+  endpointOrUrl: string,
+  method: HttpMethod,
+  data: unknown | undefined,
+  options: FetchApiJsonWithSessionRecoveryOptions,
+): Promise<TResponse> {
+  const { init, onUnauthorized, recoveryState = {} } = options;
+  const { hasAttemptedTokenRefresh, hasAttemptedTelegramMiniAppReauth } = recoveryState;
+
+  try {
+    return await fetchApiJson<TResponse>(endpointOrUrl, method, data, {
+      ...init,
+      credentials: 'include',
+    });
+  } catch (e) {
+    if (!(e instanceof ApiError) || e.statusCode !== 401) {
+      throw e;
+    }
+
+    if (!hasAttemptedTokenRefresh && !isAuthRefreshEndpoint(endpointOrUrl)) {
+      const refreshed = await postAuthRefreshSingleFlight();
+      if (refreshed) {
+        return fetchApiJsonWithSessionRecovery<TResponse>(endpointOrUrl, method, data, {
+          init,
+          onUnauthorized,
+          recoveryState: {
+            ...recoveryState,
+            hasAttemptedTokenRefresh: true,
+          },
+        });
+      }
+    }
+
+    if (
+      !hasAttemptedTelegramMiniAppReauth &&
+      !isAuthRefreshEndpoint(endpointOrUrl) &&
+      !isTelegramWebAppAuthEndpoint(endpointOrUrl)
+    ) {
+      const isReauthenticated = await postTelegramMiniAppReauth();
+      if (isReauthenticated) {
+        return fetchApiJsonWithSessionRecovery<TResponse>(endpointOrUrl, method, data, {
+          init,
+          onUnauthorized,
+          recoveryState: {
+            ...recoveryState,
+            hasAttemptedTelegramMiniAppReauth: true,
+          },
+        });
+      }
+    }
+
+    onUnauthorized?.();
+    throw e;
+  }
+}

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -8,26 +8,12 @@ const { fetchApiJsonMock } = vi.hoisted(() => ({
   fetchApiJsonMock: vi.fn(),
 }));
 
-const { clearStoredTelegramClientProfileMock, requestTelegramSignInMock } = vi.hoisted(() => ({
-  clearStoredTelegramClientProfileMock: vi.fn(),
-  requestTelegramSignInMock: vi.fn(),
-}));
-
 vi.mock('@/lib/api-session-recovery', () => ({
   fetchApiJsonWithSessionRecovery: fetchApiJsonWithSessionRecoveryMock,
 }));
 
 vi.mock('@/lib/api-core', () => ({
   fetchApiJson: fetchApiJsonMock,
-}));
-
-vi.mock('@/lib/telegram/telegram-auth', () => ({
-  clearStoredTelegramClientProfile: clearStoredTelegramClientProfileMock,
-  requestTelegramSignIn: requestTelegramSignInMock,
-}));
-
-vi.mock('@/lib/telegram/telegram-webapp', () => ({
-  isTelegramMiniApp: () => false,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -39,12 +25,10 @@ vi.mock('@/lib/logger', () => ({
 describe('apiRequest', () => {
   beforeEach(() => {
     fetchApiJsonWithSessionRecoveryMock.mockReset();
-    clearStoredTelegramClientProfileMock.mockReset();
-    requestTelegramSignInMock.mockReset();
     fetchApiJsonWithSessionRecoveryMock.mockResolvedValue({ ok: true });
   });
 
-  it('should delegate to session recovery coordinator with onUnauthorized callback', async () => {
+  it('should delegate to session recovery coordinator without onUnauthorized', async () => {
     await apiRequest('v1/admin/dashboard', 'GET');
 
     expect(fetchApiJsonWithSessionRecoveryMock).toHaveBeenCalledWith(
@@ -52,21 +36,16 @@ describe('apiRequest', () => {
       'GET',
       undefined,
       expect.objectContaining({
-        onUnauthorized: expect.any(Function),
+        init: expect.objectContaining({
+          headers: expect.any(Headers),
+        }),
       }),
     );
-  });
-
-  it('should trigger sign-in recovery when onUnauthorized runs', async () => {
-    await apiRequest('v1/admin/dashboard', 'GET');
 
     const options = fetchApiJsonWithSessionRecoveryMock.mock.calls[0]?.[3] as {
       onUnauthorized?: () => void;
     };
-    options.onUnauthorized?.();
-
-    expect(clearStoredTelegramClientProfileMock).toHaveBeenCalledTimes(1);
-    expect(requestTelegramSignInMock).toHaveBeenCalledTimes(1);
+    expect(options.onUnauthorized).toBeUndefined();
   });
 });
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -36,7 +36,7 @@ describe('apiRequest', () => {
     fetchApiJsonMock.mockResolvedValue({ ok: true });
   });
 
-  it('should call fetchApiJson with include credentials and onUnauthorized', async () => {
+  it('should call fetchApiJson with session credentials, session recovery, and onUnauthorized', async () => {
     await apiRequest('v1/admin/dashboard', 'GET');
 
     expect(fetchApiJsonMock).toHaveBeenCalledWith(
@@ -45,6 +45,7 @@ describe('apiRequest', () => {
       undefined,
       expect.objectContaining({
         credentials: 'include',
+        authRecovery: 'session',
         onUnauthorized: expect.any(Function),
       }),
     );
@@ -71,7 +72,7 @@ describe('apiPublicRequest', () => {
     fetchApiJsonMock.mockResolvedValue({ ok: true });
   });
 
-  it('should call fetchApiJson with omit credentials and without onUnauthorized', async () => {
+  it('should call fetchApiJson with omit credentials, no session recovery, and without onUnauthorized', async () => {
     await apiPublicRequest('v1/gig?limit=10', 'GET');
 
     expect(fetchApiJsonMock).toHaveBeenCalledWith(
@@ -80,6 +81,7 @@ describe('apiPublicRequest', () => {
       undefined,
       expect.objectContaining({
         credentials: 'omit',
+        authRecovery: 'none',
       }),
     );
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,5 +1,9 @@
 import { apiPublicRequest, apiRequest } from '@/lib/api';
 
+const { fetchApiJsonWithSessionRecoveryMock } = vi.hoisted(() => ({
+  fetchApiJsonWithSessionRecoveryMock: vi.fn(),
+}));
+
 const { fetchApiJsonMock } = vi.hoisted(() => ({
   fetchApiJsonMock: vi.fn(),
 }));
@@ -7,6 +11,10 @@ const { fetchApiJsonMock } = vi.hoisted(() => ({
 const { clearStoredTelegramClientProfileMock, requestTelegramSignInMock } = vi.hoisted(() => ({
   clearStoredTelegramClientProfileMock: vi.fn(),
   requestTelegramSignInMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-session-recovery', () => ({
+  fetchApiJsonWithSessionRecovery: fetchApiJsonWithSessionRecoveryMock,
 }));
 
 vi.mock('@/lib/api-core', () => ({
@@ -30,22 +38,20 @@ vi.mock('@/lib/logger', () => ({
 
 describe('apiRequest', () => {
   beforeEach(() => {
-    fetchApiJsonMock.mockReset();
+    fetchApiJsonWithSessionRecoveryMock.mockReset();
     clearStoredTelegramClientProfileMock.mockReset();
     requestTelegramSignInMock.mockReset();
-    fetchApiJsonMock.mockResolvedValue({ ok: true });
+    fetchApiJsonWithSessionRecoveryMock.mockResolvedValue({ ok: true });
   });
 
-  it('should call fetchApiJson with session credentials, session recovery, and onUnauthorized', async () => {
+  it('should delegate to session recovery coordinator with onUnauthorized callback', async () => {
     await apiRequest('v1/admin/dashboard', 'GET');
 
-    expect(fetchApiJsonMock).toHaveBeenCalledWith(
+    expect(fetchApiJsonWithSessionRecoveryMock).toHaveBeenCalledWith(
       'v1/admin/dashboard',
       'GET',
       undefined,
       expect.objectContaining({
-        credentials: 'include',
-        authRecovery: 'session',
         onUnauthorized: expect.any(Function),
       }),
     );
@@ -54,10 +60,10 @@ describe('apiRequest', () => {
   it('should trigger sign-in recovery when onUnauthorized runs', async () => {
     await apiRequest('v1/admin/dashboard', 'GET');
 
-    const init = fetchApiJsonMock.mock.calls[0]?.[3] as {
+    const options = fetchApiJsonWithSessionRecoveryMock.mock.calls[0]?.[3] as {
       onUnauthorized?: () => void;
     };
-    init.onUnauthorized?.();
+    options.onUnauthorized?.();
 
     expect(clearStoredTelegramClientProfileMock).toHaveBeenCalledTimes(1);
     expect(requestTelegramSignInMock).toHaveBeenCalledTimes(1);
@@ -67,12 +73,11 @@ describe('apiRequest', () => {
 describe('apiPublicRequest', () => {
   beforeEach(() => {
     fetchApiJsonMock.mockReset();
-    clearStoredTelegramClientProfileMock.mockReset();
-    requestTelegramSignInMock.mockReset();
+    fetchApiJsonWithSessionRecoveryMock.mockReset();
     fetchApiJsonMock.mockResolvedValue({ ok: true });
   });
 
-  it('should call fetchApiJson with omit credentials, no session recovery, and without onUnauthorized', async () => {
+  it('should call pure transport with omit credentials and without session recovery', async () => {
     await apiPublicRequest('v1/gig?limit=10', 'GET');
 
     expect(fetchApiJsonMock).toHaveBeenCalledWith(
@@ -81,11 +86,8 @@ describe('apiPublicRequest', () => {
       undefined,
       expect.objectContaining({
         credentials: 'omit',
-        authRecovery: 'none',
       }),
     );
-
-    const init = fetchApiJsonMock.mock.calls[0]?.[3] as Record<string, unknown>;
-    expect(init.onUnauthorized).toBeUndefined();
+    expect(fetchApiJsonWithSessionRecoveryMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -1,19 +1,11 @@
-import { apiPublicRequest, apiRequest } from '@/lib/api';
+import { apiRequest } from '@/lib/api';
 
 const { fetchApiJsonWithSessionRecoveryMock } = vi.hoisted(() => ({
   fetchApiJsonWithSessionRecoveryMock: vi.fn(),
 }));
 
-const { fetchApiJsonMock } = vi.hoisted(() => ({
-  fetchApiJsonMock: vi.fn(),
-}));
-
 vi.mock('@/lib/api-session-recovery', () => ({
   fetchApiJsonWithSessionRecovery: fetchApiJsonWithSessionRecoveryMock,
-}));
-
-vi.mock('@/lib/api-core', () => ({
-  fetchApiJson: fetchApiJsonMock,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -46,27 +38,5 @@ describe('apiRequest', () => {
       onUnauthorized?: () => void;
     };
     expect(options.onUnauthorized).toBeUndefined();
-  });
-});
-
-describe('apiPublicRequest', () => {
-  beforeEach(() => {
-    fetchApiJsonMock.mockReset();
-    fetchApiJsonWithSessionRecoveryMock.mockReset();
-    fetchApiJsonMock.mockResolvedValue({ ok: true });
-  });
-
-  it('should call pure transport with omit credentials and without session recovery', async () => {
-    await apiPublicRequest('v1/gig?limit=10', 'GET');
-
-    expect(fetchApiJsonMock).toHaveBeenCalledWith(
-      'v1/gig?limit=10',
-      'GET',
-      undefined,
-      expect.objectContaining({
-        credentials: 'omit',
-      }),
-    );
-    expect(fetchApiJsonWithSessionRecoveryMock).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import { fetchApiJson } from '@/lib/api-core';
 import type { FetchApiJsonOptions } from '@/lib/api-core';
+import { fetchApiJsonWithSessionRecovery } from '@/lib/api-session-recovery';
 import { logger } from '@/lib/logger';
 import {
   clearStoredTelegramClientProfile,
@@ -15,7 +16,7 @@ export {
 
 type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-type ApiRequestInit = Omit<FetchApiJsonOptions, 'credentials' | 'authRecovery' | 'onUnauthorized'>;
+type ApiRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
 
 /**
  * Authenticated / session API call. Sends cookies and runs sign-in recovery on 401.
@@ -28,11 +29,11 @@ export async function apiRequest<TResponse = unknown, TBody = unknown>(
 ): Promise<TResponse> {
   try {
     const headers = new Headers(init?.headers);
-    return await fetchApiJson<TResponse>(endpointOrUrl, method, data, {
-      ...init,
-      headers,
-      credentials: 'include',
-      authRecovery: 'session',
+    return await fetchApiJsonWithSessionRecovery<TResponse>(endpointOrUrl, method, data, {
+      init: {
+        ...init,
+        headers,
+      },
       onUnauthorized: () => {
         clearStoredTelegramClientProfile();
         if (!isTelegramMiniApp()) {
@@ -62,7 +63,6 @@ export async function apiPublicRequest<TResponse = unknown, TBody = unknown>(
       ...init,
       headers,
       credentials: 'omit',
-      authRecovery: 'none',
     });
   } catch (e) {
     logger.errorFromUnknown('api_public_request_failed', e, { endpointOrUrl, method });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,11 +2,6 @@ import { fetchApiJson } from '@/lib/api-core';
 import type { FetchApiJsonOptions } from '@/lib/api-core';
 import { fetchApiJsonWithSessionRecovery } from '@/lib/api-session-recovery';
 import { logger } from '@/lib/logger';
-import {
-  clearStoredTelegramClientProfile,
-  requestTelegramSignIn,
-} from '@/lib/telegram/telegram-auth';
-import { isTelegramMiniApp } from '@/lib/telegram/telegram-webapp';
 
 export {
   ApiError,
@@ -19,7 +14,8 @@ type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 type ApiRequestInit = Omit<FetchApiJsonOptions, 'credentials'>;
 
 /**
- * Authenticated / session API call. Sends cookies and runs sign-in recovery on 401.
+ * Session API call with cookie auth and transport-level session recovery.
+ * Does not trigger client sign-in UI; use {@link apiClientRequest} in browser code.
  */
 export async function apiRequest<TResponse = unknown, TBody = unknown>(
   endpointOrUrl: string,
@@ -33,12 +29,6 @@ export async function apiRequest<TResponse = unknown, TBody = unknown>(
       init: {
         ...init,
         headers,
-      },
-      onUnauthorized: () => {
-        clearStoredTelegramClientProfile();
-        if (!isTelegramMiniApp()) {
-          requestTelegramSignIn();
-        }
       },
     });
   } catch (e) {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,8 +1,8 @@
-import { fetchApiJson } from '@/lib/api-core';
 import type { FetchApiJsonOptions } from '@/lib/api-core';
 import { fetchApiJsonWithSessionRecovery } from '@/lib/api-session-recovery';
 import { logger } from '@/lib/logger';
 
+export { apiPublicRequest } from '@/lib/api-public';
 export {
   ApiError,
   TELEGRAM_INIT_DATA_EXPIRED_CODE,
@@ -33,29 +33,6 @@ export async function apiRequest<TResponse = unknown, TBody = unknown>(
     });
   } catch (e) {
     logger.errorFromUnknown('api_request_failed', e, { endpointOrUrl, method });
-    throw e;
-  }
-}
-
-/**
- * Public API call. Omits cookies and disables session recovery.
- * Next.js cache behavior is configured explicitly at each server call site.
- */
-export async function apiPublicRequest<TResponse = unknown, TBody = unknown>(
-  endpointOrUrl: string,
-  method: HttpMethod,
-  data?: TBody,
-  init?: ApiRequestInit,
-): Promise<TResponse> {
-  try {
-    const headers = new Headers(init?.headers);
-    return await fetchApiJson<TResponse>(endpointOrUrl, method, data, {
-      ...init,
-      headers,
-      credentials: 'omit',
-    });
-  } catch (e) {
-    logger.errorFromUnknown('api_public_request_failed', e, { endpointOrUrl, method });
     throw e;
   }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,7 @@ export {
 
 type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-type ApiRequestInit = Omit<FetchApiJsonOptions, 'credentials' | 'onUnauthorized'>;
+type ApiRequestInit = Omit<FetchApiJsonOptions, 'credentials' | 'authRecovery' | 'onUnauthorized'>;
 
 /**
  * Authenticated / session API call. Sends cookies and runs sign-in recovery on 401.
@@ -32,6 +32,7 @@ export async function apiRequest<TResponse = unknown, TBody = unknown>(
       ...init,
       headers,
       credentials: 'include',
+      authRecovery: 'session',
       onUnauthorized: () => {
         clearStoredTelegramClientProfile();
         if (!isTelegramMiniApp()) {
@@ -46,8 +47,8 @@ export async function apiRequest<TResponse = unknown, TBody = unknown>(
 }
 
 /**
- * Public API call. Omits cookies so Next can cache server fetches for SSG/ISR.
- * Does not trigger sign-in UI on 401.
+ * Public API call. Omits cookies and disables session recovery.
+ * Next.js cache behavior is configured explicitly at each server call site.
  */
 export async function apiPublicRequest<TResponse = unknown, TBody = unknown>(
   endpointOrUrl: string,
@@ -61,6 +62,7 @@ export async function apiPublicRequest<TResponse = unknown, TBody = unknown>(
       ...init,
       headers,
       credentials: 'omit',
+      authRecovery: 'none',
     });
   } catch (e) {
     logger.errorFromUnknown('api_public_request_failed', e, { endpointOrUrl, method });

--- a/src/lib/feed/feed.mapper.test.ts
+++ b/src/lib/feed/feed.mapper.test.ts
@@ -1,4 +1,4 @@
-import { gigDateToYMD } from '@/lib/feed/feed.mapper';
+import { gigDateToYMD, gigDatesToSortedUniqueYmd } from '@/lib/feed/feed.mapper';
 import { toLocalYMD } from '@/lib/utils';
 
 describe('gigDateToYMD', () => {
@@ -47,5 +47,21 @@ describe('gigDateToYMD', () => {
 
   it('should throw when unix timestamp has unsupported precision', () => {
     expect(() => gigDateToYMD('170000000000')).toThrow('10 (seconds) or 13 (milliseconds)');
+  });
+});
+
+describe('gigDatesToSortedUniqueYmd', () => {
+  it('should normalize mixed raw date formats into sorted unique YMD values', () => {
+    const unixSeconds = 1_700_000_000;
+
+    const result = gigDatesToSortedUniqueYmd([
+      '2026-04-21',
+      '2026-04-21T12:00:00.000Z',
+      unixSeconds,
+    ]);
+
+    expect(result).toEqual(
+      Array.from(new Set(['2026-04-21', toLocalYMD(new Date(unixSeconds * 1000))])).sort(),
+    );
   });
 });

--- a/src/lib/feed/feed.mapper.ts
+++ b/src/lib/feed/feed.mapper.ts
@@ -1,8 +1,10 @@
-import type { Event, V1GigGetResponseBodyGig } from '@/lib/types';
+import type { Event, V1GigDatesGetResponseBody, V1GigGetResponseBodyGig } from '@/lib/types';
 import { toLocalYMD } from '@/lib/utils';
 
 export type CountryNameResolver = (iso: string) => string;
 export type CityNameResolver = (code: string) => string;
+export type GigDateInput = V1GigGetResponseBodyGig['date'] | number;
+export type GigDatesInput = V1GigDatesGetResponseBody['dates'];
 
 export interface GigToEventOptions {
   readonly resolveCountryName?: CountryNameResolver;
@@ -45,7 +47,7 @@ function parseUnixTimestampToYmd(value: string): string {
   );
 }
 
-export function gigDateToYMD(date: V1GigGetResponseBodyGig['date'] | number): string {
+export function gigDateToYMD(date: GigDateInput): string {
   if (typeof date === 'number') {
     if (!Number.isFinite(date) || !Number.isInteger(date)) {
       throw new Error(
@@ -85,6 +87,11 @@ export function gigDateToYMD(date: V1GigGetResponseBodyGig['date'] | number): st
   throw new Error(
     `Invalid gig date "${value}": expected YYYY-MM-DD, ISO date-time, or unix timestamp (10/13 digits)`,
   );
+}
+
+export function gigDatesToSortedUniqueYmd(dates: GigDatesInput): string[] {
+  const ymd = dates.map((date) => gigDateToYMD(date));
+  return Array.from(new Set(ymd)).sort();
 }
 
 export function gigToEvent(gig: V1GigGetResponseBodyGig, options: GigToEventOptions = {}): Event {

--- a/src/lib/i18n/translations.server.test.ts
+++ b/src/lib/i18n/translations.server.test.ts
@@ -4,7 +4,7 @@ const { getTranslationsApiPublicRequestMock } = vi.hoisted(() => ({
 
 vi.mock('server-only', () => ({}));
 
-vi.mock('@/lib/api', () => ({
+vi.mock('@/lib/api-public', () => ({
   apiPublicRequest: getTranslationsApiPublicRequestMock,
 }));
 

--- a/src/lib/i18n/translations.server.ts
+++ b/src/lib/i18n/translations.server.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { apiPublicRequest } from '@/lib/api';
+import { apiPublicRequest } from '@/lib/api-public';
 import { parseLocaleGetTranslationsResponseBody } from '@/lib/api-boundary-schemas';
 import type { V1LocaleGetTranslationsResponseBody } from '@/lib/api-boundary-schemas';
 import {

--- a/src/lib/telegram/telegram-auth.ts
+++ b/src/lib/telegram/telegram-auth.ts
@@ -210,6 +210,7 @@ export async function signOutTelegramAuthOnServer(): Promise<void> {
   try {
     await fetchApiJson<unknown>('v1/auth/logout', 'POST', undefined, {
       credentials: 'include',
+      authRecovery: 'none',
     });
   } catch {
     /* best-effort: still clear local profile */
@@ -223,7 +224,7 @@ export async function exchangeTelegramAuthFromWebApp(initData: string): Promise<
     {
       initData,
     },
-    { credentials: 'include' },
+    { credentials: 'include', authRecovery: 'none' },
   );
   const { profile } = parseAuthExchangeResponse(raw);
   setStoredTelegramClientProfile(profile);
@@ -268,6 +269,7 @@ export async function exchangeTelegramAuthFromLoginWidget(
 ): Promise<TelegramAuthExchangeResponse> {
   const raw = await fetchApiJson<unknown>('v1/auth/telegram/login-widget', 'POST', user, {
     credentials: 'include',
+    authRecovery: 'none',
   });
   const response = parseAuthExchangeResponse(raw);
   setStoredTelegramClientProfile(response.profile);

--- a/src/lib/telegram/telegram-auth.ts
+++ b/src/lib/telegram/telegram-auth.ts
@@ -210,7 +210,6 @@ export async function signOutTelegramAuthOnServer(): Promise<void> {
   try {
     await fetchApiJson<unknown>('v1/auth/logout', 'POST', undefined, {
       credentials: 'include',
-      authRecovery: 'none',
     });
   } catch {
     /* best-effort: still clear local profile */
@@ -224,7 +223,7 @@ export async function exchangeTelegramAuthFromWebApp(initData: string): Promise<
     {
       initData,
     },
-    { credentials: 'include', authRecovery: 'none' },
+    { credentials: 'include' },
   );
   const { profile } = parseAuthExchangeResponse(raw);
   setStoredTelegramClientProfile(profile);
@@ -269,7 +268,6 @@ export async function exchangeTelegramAuthFromLoginWidget(
 ): Promise<TelegramAuthExchangeResponse> {
   const raw = await fetchApiJson<unknown>('v1/auth/telegram/login-widget', 'POST', user, {
     credentials: 'include',
-    authRecovery: 'none',
   });
   const response = parseAuthExchangeResponse(raw);
   setStoredTelegramClientProfile(response.profile);


### PR DESCRIPTION
## Summary

- Split the API client into clear layers: thin `api-core` transport, `api-public` (no cookies/session), `api-session-recovery` (refresh + Telegram Mini App re-auth), and `api-session-client` (unauthorized UI).
- Harden `fetchApiJson` / `buildUrl`: support empty bodies (`204` / `HEAD`) and `*+json` content types; allow only relative `v1/` endpoints (no absolute URLs / `..`).
- Make feed server loaders thin wrappers over `feedApi` (paths owned by the endpoint module; ISR options stay on the server).
- Extract `Country` into `countries.types.ts` so clients do not import server-only modules for types.
- Document HTTP/runtime boundaries and type colocation rules in `AGENTS.md`.

## Test plan

### Public feed
- [x] Open `/feed` and location feeds (`/feed/{country}`, `/feed/{country}/{city}`) — initial SSR load works
- [x] Infinite scroll / load more and “around date” navigation still work
- [x] Calendar available dates load for a city with gigs
- [x] Deep-link / open a gig by public id (anchor date) still works

### Auth & session recovery (critical)
- [x] Authenticated admin API calls still succeed with a valid session
- [x] Expired access token: refresh recovers the request (no forced sign-in on first 401)
- [ ] Failed refresh: browser shows Telegram sign-in UI; Mini App does **not** open the browser sign-in flow
- [ ] Telegram Mini App: after refresh failure, Mini App re-auth recovers the session and retries the request
- [ ] Final 401 after recovery attempts: profile cleared + sign-in UX as before

### Admin
- [ ] Create / edit gig form: countries load, lookup, submit, and updates still work
- [ ] Other admin authenticated endpoints used in the UI still work

### Regression / smoke
- [ ] Public (unauthenticated) pages do not send cookies / do not trigger session recovery
- [ ] Endpoints that return `204` / empty body do not break the client
- [ ] No console/runtime import errors around `api-public` / `*.server` / client bundles